### PR TITLE
[C020-C023] Player availability subsystem, confidence scores & Jenkins CI fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,9 @@ pipeline {
         GCP_CREDS_ID = 'gcp-service-account-key' 
         GCP_CONFIG_ID = 'gcp-config-sh'
         PIP_CACHE_DIR = "${WORKSPACE}/.pip-cache"
+        VENV_DIR      = "${WORKSPACE}/.venv"
+        PY            = "${WORKSPACE}/.venv/bin/python3"
+        PIP           = "${WORKSPACE}/.venv/bin/pip"
     }
 
     stages {
@@ -35,29 +38,37 @@ pipeline {
                     file(credentialsId: "${GCP_CREDS_ID}", variable: 'GCP_KEY'),
                     file(credentialsId: "${GCP_CONFIG_ID}", variable: 'SECURE_CONFIG')
                 ]) {
-                    sh """#!/bin/bash
+                    sh '''#!/bin/bash
                         # Inject the secret config into the expected script location
                         mkdir -p scripts
-                        cp ${SECURE_CONFIG} scripts/gcp_config.sh
+                        cp "$SECURE_CONFIG" scripts/gcp_config.sh
                         chmod +x scripts/*.sh
-                        
+
                         # Authenticate
                         source scripts/gcp_config.sh
-                        gcloud auth activate-service-account --key-file=${GCP_KEY} --quiet
-                        gcloud config set project \$PROJECT_ID --quiet
-                    """
+                        gcloud auth activate-service-account --key-file="$GCP_KEY" --quiet
+                        gcloud config set project "$PROJECT_ID" --quiet
+                    '''
                 }
+            }
+        }
+
+        stage('Setup Python') {
+            steps {
+                sh """#!/bin/bash
+                    python3 -m venv ${VENV_DIR}
+                    ${PIP} install --upgrade pip --quiet
+                    ${PIP} install --cache-dir ${PIP_CACHE_DIR} -r requirements.txt --quiet
+                """
             }
         }
 
         stage('Quality Check') {
             steps {
                 sh """#!/bin/bash
-                    mkdir -p ${PIP_CACHE_DIR}
-                    python3 -m pip install --upgrade pip
-                    python3 -m pip install --cache-dir ${PIP_CACHE_DIR} flake8
+                    ${PIP} install --cache-dir ${PIP_CACHE_DIR} flake8 --quiet
                     # || true ensures we don't fail the build on style warnings for now
-                    python3 -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics || true
+                    ${VENV_DIR}/bin/flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics || true
                 """
             }
         }
@@ -65,17 +76,16 @@ pipeline {
         stage('Unit Tests') {
             steps {
                 sh """#!/bin/bash
-                    python3 -m pip install --cache-dir ${PIP_CACHE_DIR} -r requirements.txt
-                    python3 -m pytest tests/ -v --tb=short
+                    ${PY} -m pytest tests/ -v --tb=short
                 """
             }
         }
 
         stage('Deploy & Create Job') {
-            // Deploy on master, dev, or any hotfix branch
+            // Deploy on master, dev, hotfix, or any feature branch
             when {
-                expression { 
-                    return (CLEAN_BRANCH == 'master' || CLEAN_BRANCH == 'dev' || CLEAN_BRANCH.startsWith('hotfix-'))
+                expression {
+                    return (CLEAN_BRANCH == 'master' || CLEAN_BRANCH == 'dev' || RAW_BRANCH.contains('hotfix-') || RAW_BRANCH.contains('feature/'))
                 }
             }
             steps {
@@ -91,9 +101,10 @@ pipeline {
         }
 
         stage('Smoke Test') {
+            // Run on master, dev, hotfix, or any feature branch
             when {
-                expression { 
-                    return (CLEAN_BRANCH == 'master' || CLEAN_BRANCH == 'dev' || CLEAN_BRANCH.startsWith('hotfix-'))
+                expression {
+                    return (CLEAN_BRANCH == 'master' || CLEAN_BRANCH == 'dev' || RAW_BRANCH.contains('hotfix-') || RAW_BRANCH.contains('feature/'))
                 }
             }
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,6 +61,15 @@ pipeline {
                 """
             }
         }
+        
+        stage('Unit Tests') {
+            steps {
+                sh """#!/bin/bash
+                    python3 -m pip install --cache-dir ${PIP_CACHE_DIR} -r requirements.txt
+                    python3 -m pytest tests/ -v --tb=short
+                """
+            }
+        }
 
         stage('Deploy & Create Job') {
             // Deploy on master, dev, or any hotfix branch

--- a/common/constants.py
+++ b/common/constants.py
@@ -3,7 +3,7 @@ This module contains common utility constants for NBA data processing.
 """
 
 # Nba api timeout
-nba_api_timeout: int = 60   # increased from 20 – proxy adds latency
+nba_api_timeout: int = 60  # increased from 20 – proxy adds latency
 # Number of retries for nba api requests
 max_retries: int = 3
 # Delay between retries in seconds
@@ -11,62 +11,55 @@ retry_delay: int = 10
 
 # key statistics for points ML models
 key_stats_points: dict[str, str] = {
-    'usagePercentage': 'raw stats',
-    'trueShootingPercentage': 'raw stats',
-    'effectiveFieldGoalPercentage': 'raw stats',
-    'offensiveRating': 'raw stats',
-    'freeThrowsMade': 'raw stats',
-    'threePointersMade': 'raw stats',
-    'fieldGoalsMade': 'raw stats',
-    'avg_points_opp_position_last_10': 'engineering stats',
-    'avg_points_opp_position_last_20': 'engineering stats',
-    'avg_points_opp_position_all': 'engineering stats',
+    "usagePercentage": "raw stats",
+    "trueShootingPercentage": "raw stats",
+    "effectiveFieldGoalPercentage": "raw stats",
+    "offensiveRating": "raw stats",
+    "freeThrowsMade": "raw stats",
+    "threePointersMade": "raw stats",
+    "fieldGoalsMade": "raw stats",
+    "avg_points_opp_position_last_10": "engineering stats",
+    "avg_points_opp_position_last_20": "engineering stats",
+    "avg_points_opp_position_all": "engineering stats",
 }
 
 # Categorical features for points ML models
-categorical_cols_points: list[str] = [
-    'is_home', 
-    'season'
-]
+categorical_cols_points: list[str] = ["is_home", "season"]
 
 # target variable for points ML models
-target_variable_points: str = 'points'
+target_variable_points: str = "points"
 
 # key statistics for fantasy ML models
 key_stats_fantasy: dict[str, str] = {
-    'points': 'raw stats',
-    'fieldGoalsMade': 'raw stats',
-    'fieldGoalsAttempted': 'raw stats',
-    'possessions': 'raw stats',
-    'reboundsTotal': 'raw stats',
-    'assists': 'raw stats',
-    'threePointersMade': 'raw stats',
-    'threePointersAttempted': 'raw stats',
-    'usagePercentage': 'raw stats',
-    'freeThrowsMade': 'raw stats',
-    'freeThrowsAttempted': 'raw stats',
-    'trueShootingPercentage': 'raw stats',
-    'offensiveRating': 'raw stats',
-    'effectiveFieldGoalPercentage': 'raw stats',
-    'turnovers': 'raw stats',
-    'assistToTurnover': 'raw stats',
-    'steals': 'raw stats',
-    'blocks': 'raw stats',
-    'avg_fantasy_points_opp_position_last_10': 'engineering stats',
-    'avg_fantasy_points_opp_position_last_20': 'engineering stats',
-    'avg_fantasy_points_opp_position_all': 'engineering stats',
+    "points": "raw stats",
+    "fieldGoalsMade": "raw stats",
+    "fieldGoalsAttempted": "raw stats",
+    "possessions": "raw stats",
+    "reboundsTotal": "raw stats",
+    "assists": "raw stats",
+    "threePointersMade": "raw stats",
+    "threePointersAttempted": "raw stats",
+    "usagePercentage": "raw stats",
+    "freeThrowsMade": "raw stats",
+    "freeThrowsAttempted": "raw stats",
+    "trueShootingPercentage": "raw stats",
+    "offensiveRating": "raw stats",
+    "effectiveFieldGoalPercentage": "raw stats",
+    "turnovers": "raw stats",
+    "assistToTurnover": "raw stats",
+    "steals": "raw stats",
+    "blocks": "raw stats",
+    "avg_fantasy_points_opp_position_last_10": "engineering stats",
+    "avg_fantasy_points_opp_position_last_20": "engineering stats",
+    "avg_fantasy_points_opp_position_all": "engineering stats",
 }
 
 
 # Categorical features for fantasy ML models
-categorical_cols_fantasy: list[str] = [
-    'is_home', 
-    'season',
-    'position_group'
-]
+categorical_cols_fantasy: list[str] = ["is_home", "season", "position_group"]
 
 # target variable for fantasy ML models
-target_variable_fantasy: str = 'fantasy_points'
+target_variable_fantasy: str = "fantasy_points"
 # Rolling windows for fantasy ML models
 rolling_windows_fantasy: list[int] = [3, 7, 15, 30]
 rolling_windows_points: list[int] = [5, 10, 20]
@@ -77,25 +70,84 @@ MEASURE_PREDICTED_FANTASY_POINTS: int = 2
 MEASURE_POINTS_VOLATILITY: int = 3
 MEASURE_FANTASY_VOLATILITY: int = 4
 
+# ---------------------------------------------------------------------------
+# Availability subsystem constants
+# ---------------------------------------------------------------------------
+
+# Maps raw PDF status strings (upper-cased) to one of the five canonical levels.
+# Keys are matched first by exact equality, then as regex sub-patterns, in the
+# order defined here.  The first match wins.
+AVAILABILITY_STATUS_MAP: dict[str, str] = {
+    # --- Out variants ---
+    "OUT": "Out",
+    "DNP": "Out",
+    "DND": "Out",
+    "NWT": "Out",  # Not With Team
+    "INACTIVE": "Out",
+    "SUSPENDED": "Out",
+    r"OUT\b": "Out",  # fallback regex
+    r"DO NOT PLAY": "Out",
+    # --- Doubtful variants ---
+    "DOUBTFUL": "Doubtful",
+    r"DOUBTFUL\b": "Doubtful",
+    # --- Questionable / Game-Time Decision variants ---
+    "QUESTIONABLE": "Questionable",
+    "GTD": "Questionable",  # Game-Time Decision
+    "GAME TIME DECISION": "Questionable",
+    r"QUESTIONABLE\b": "Questionable",
+    # --- Probable variants ---
+    "PROBABLE": "Probable",
+    r"PROBABLE\b": "Probable",
+    # --- Available / no restriction ---
+    "AVAILABLE": "Available",
+    "ACTIVE": "Available",
+    r"AVAILABLE\b": "Available",
+}
+
+# Prior play-probability assigned to each canonical status.
+# These are empirical calibrations; adjust as you collect outcome data.
+AVAILABILITY_PLAY_PROBABILITY: dict[str, float] = {
+    "Out": 0.02,
+    "Doubtful": 0.15,
+    "Questionable": 0.50,
+    "Probable": 0.85,
+    "Available": 0.97,
+}
+
+# Minimum play_probability for is_available=True in the downstream table.
+AVAILABILITY_DEFAULT_THRESHOLD: float = 0.50
+
+# Players with play_probability strictly below this threshold are excluded from
+# predictions entirely. Set to just above "Out" (0.02) so that only Out players
+# are excluded; Doubtful (0.15) and above receive a prediction row.
+PREDICTION_EXCLUDE_THRESHOLD: float = 0.10
+
+# Confidence score parameters.
+# stability   = 1 - min(volatility / CONFIDENCE_MAX_VOLATILITY, 1.0)
+# sample_conf = min(games_played / CONFIDENCE_SAMPLE_SIZE_CAP, 1.0)
+# confidence  = play_probability * stability * sample_conf
+CONFIDENCE_MAX_VOLATILITY: float = 25.0  # std dev cap; beyond this → stability = 0
+CONFIDENCE_SAMPLE_SIZE_CAP: int = 20  # games to reach full sample confidence
+
 # Target configuration - centralized settings for each target variable
 # To add a new target, simply add a new entry to this dictionary
 TARGET_CONFIGS: dict[str, dict] = {
-    'points': {
-        'key_stats': key_stats_points,
-        'categorical_cols': categorical_cols_points,
-        'target_variable': target_variable_points,
-        'rolling_windows': rolling_windows_points,
-        'measure_prediction': MEASURE_PREDICTED_POINTS,
-        'measure_volatility': MEASURE_POINTS_VOLATILITY,
-        'target_computer_fn': None  # No computation needed, already in data
+    "points": {
+        "key_stats": key_stats_points,
+        "categorical_cols": categorical_cols_points,
+        "target_variable": target_variable_points,
+        "rolling_windows": rolling_windows_points,
+        "measure_prediction": MEASURE_PREDICTED_POINTS,
+        "measure_volatility": MEASURE_POINTS_VOLATILITY,
+        "target_computer_fn": None,  # No computation needed, already in data
     },
-    'fantasy_points': {
-        'key_stats': key_stats_fantasy,
-        'categorical_cols': categorical_cols_fantasy,
-        'target_variable': target_variable_fantasy,
-        'rolling_windows': rolling_windows_fantasy,
-        'measure_prediction': MEASURE_PREDICTED_FANTASY_POINTS,
-        'measure_volatility': MEASURE_FANTASY_VOLATILITY,
-        'target_computer_fn': 'compute_fantasy_points'  # String reference to avoid circular import
-    }
+    "fantasy_points": {
+        "key_stats": key_stats_fantasy,
+        "categorical_cols": categorical_cols_fantasy,
+        "target_variable": target_variable_fantasy,
+        "rolling_windows": rolling_windows_fantasy,
+        "measure_prediction": MEASURE_PREDICTED_FANTASY_POINTS,
+        "measure_volatility": MEASURE_FANTASY_VOLATILITY,
+        "target_computer_fn": "compute_fantasy_points",  # String reference to avoid circular import
+    },
 }

--- a/common/feature_engineering.py
+++ b/common/feature_engineering.py
@@ -5,226 +5,261 @@ from typing import List, Dict, Tuple, Any
 from sklearn.preprocessing import OneHotEncoder
 from common.utils import parse_minutes
 
-def merge_data(box: pd.DataFrame, adv: pd.DataFrame, players: pd.DataFrame) -> pd.DataFrame:
+
+def merge_data(
+    box: pd.DataFrame, adv: pd.DataFrame, players: pd.DataFrame
+) -> pd.DataFrame:
     """
     Merge boxscore, advanced stats, and players data.
-    
+
     Args:
         box (pd.DataFrame): Basic boxscore data.
         adv (pd.DataFrame): Advanced boxscore data.
         players (pd.DataFrame): Players data.
-        
+
     Returns:
         pd.DataFrame: Merged DataFrame.
     """
-    # Merge boxscore df + players 
+    # Merge boxscore df + players
     df_merged = box.merge(
-        players[['person_id', 'position']].rename(columns={'position': 'position_player'}),
-        left_on='personId', right_on='person_id', how='left'
-    ).drop('person_id', axis=1)
+        players[["person_id", "position"]].rename(
+            columns={"position": "position_player"}
+        ),
+        left_on="personId",
+        right_on="person_id",
+        how="left",
+    ).drop("person_id", axis=1)
 
     # Merge advanced stats with boxscore + players
     ## a) Define merge keys for box + adv
-    merge_keys = ['gameId', 'personId', 'teamId']
-    
+    merge_keys = ["gameId", "personId", "teamId"]
+
     ## b) Identify new columns from advanced stats
-    adv_new_cols = [col for col in adv.columns if col not in box.columns or col in merge_keys]
-    
+    adv_new_cols = [
+        col for col in adv.columns if col not in box.columns or col in merge_keys
+    ]
+
     ## c) Perform the merge
     df = df_merged.merge(
-        adv[adv_new_cols],
-        left_on=merge_keys,
-        right_on=merge_keys,
-        how='left'
+        adv[adv_new_cols], left_on=merge_keys, right_on=merge_keys, how="left"
     )
-    
+
     return df
+
 
 def preprocess_data(df: pd.DataFrame) -> pd.DataFrame:
     """
     Preprocess the data: parse minutes, handle positions, dates, season, home/away.
-    
+
     Args:
         df (pd.DataFrame): Merged DataFrame.
-        
+
     Returns:
         pd.DataFrame: Preprocessed DataFrame.
     """
     # Transform minutes from string to float
-    if 'minutes' in df.columns and df['minutes'].dtype == 'object':
-        df['minutes'] = df['minutes'].apply(parse_minutes)
+    if "minutes" in df.columns and df["minutes"].dtype == "object":
+        df["minutes"] = df["minutes"].apply(parse_minutes)
 
     # fill NaN values in 'position' with 'BENCH'
-    if 'position' in df.columns:
-        df['position'] = df['position'].fillna('BENCH')
-    
-    # Create a new column 'position_group' based on 'POSITION' and 'position' 
-    if 'position' in df.columns and 'position_player' in df.columns:
-        df['position_group'] = df.apply(
-            lambda x: 'G' if x['position'] in ('G', 'BENCH') and x['position_player'] in ('G', 'G-F') else
-                    'F' if x['position'] in ('F', 'BENCH') and x['position_player'] in ('F', 'F-G', 'F-C') else
-                    'C' if x['position'] in ('C', 'BENCH') and x['position_player'] in ('C', 'C-F') else x['position'],
-            axis=1
+    if "position" in df.columns:
+        df["position"] = df["position"].fillna("BENCH")
+
+    # Create a new column 'position_group' based on 'POSITION' and 'position'
+    if "position" in df.columns and "position_player" in df.columns:
+        df["position_group"] = df.apply(
+            lambda x: "G"
+            if x["position"] in ("G", "BENCH") and x["position_player"] in ("G", "G-F")
+            else "F"
+            if x["position"] in ("F", "BENCH")
+            and x["position_player"] in ("F", "F-G", "F-C")
+            else "C"
+            if x["position"] in ("C", "BENCH") and x["position_player"] in ("C", "C-F")
+            else x["position"],
+            axis=1,
         )
-        
+
         # Filter out players where position_group is still 'BENCH' (likely missing player info or deep bench)
-        df = df[df['position_group'] != 'BENCH']
+        df = df[df["position_group"] != "BENCH"]
 
     # Remove rows with no minutes (DNP)
-    if 'minutes' in df.columns:
-        df = df[df['minutes'].notna()]
+    if "minutes" in df.columns:
+        df = df[df["minutes"].notna()]
 
-    # Change column date type to datetime 
-    if 'game_date' in df.columns:
-        df['game_date'] = pd.to_datetime(df['game_date'])
-    
-    # Add a season column based on the game_id 
-    if 'gameId' in df.columns:
-        df['season'] = df['gameId'].astype(str).str[1:3].astype(int) + 2000
+    # Change column date type to datetime
+    if "game_date" in df.columns:
+        df["game_date"] = pd.to_datetime(df["game_date"])
+
+    # Add a season column based on the game_id
+    if "gameId" in df.columns:
+        df["season"] = df["gameId"].astype(str).str[1:3].astype(int) + 2000
 
     # Feature engineering
-    if 'teamId' in df.columns and 'home_team_id' in df.columns and 'visitor_team_id' in df.columns:
-        df['is_home'] = df['teamId'] == df['home_team_id']
-        df['opponent'] = np.where(df['is_home'], df['visitor_team_id'], df['home_team_id'])
+    if (
+        "teamId" in df.columns
+        and "home_team_id" in df.columns
+        and "visitor_team_id" in df.columns
+    ):
+        df["is_home"] = df["teamId"] == df["home_team_id"]
+        df["opponent"] = np.where(
+            df["is_home"], df["visitor_team_id"], df["home_team_id"]
+        )
 
     # Calculate rest days
-    if 'teamId' in df.columns and 'game_date' in df.columns:
-        df = df.sort_values(['teamId', 'game_date'])
-        df['rest_days'] = df.groupby('teamId')['game_date'].diff().dt.days
-        df['rest_days'] = df['rest_days'].fillna(3) # Default to 3 days rest for first game
-        df['rest_days'] = df['rest_days'].clip(upper=7) # Cap at 7 days
+    if "teamId" in df.columns and "game_date" in df.columns:
+        df = df.sort_values(["teamId", "game_date"])
+        df["rest_days"] = df.groupby("teamId")["game_date"].diff().dt.days
+        df["rest_days"] = df["rest_days"].fillna(
+            3
+        )  # Default to 3 days rest for first game
+        df["rest_days"] = df["rest_days"].clip(upper=7)  # Cap at 7 days
 
     return df
 
-def create_historical_features(df: pd.DataFrame, target_col: str = 'points') -> pd.DataFrame:
+
+def create_historical_features(
+    df: pd.DataFrame, target_col: str = "points"
+) -> pd.DataFrame:
     """
     Create historical performance features based on position group opponent and game date (time aware).
-    
+
     Args:
         df (pd.DataFrame): The input DataFrame already prepared with basic features.
         target_col (str): The target column to compute historical averages for (e.g., 'points' or 'fantasy_points').
-        
+
     Returns:
         pd.DataFrame: The DataFrame with historical features added.
     """
     # Filter out bench players and copy to avoid SettingWithCopyWarning
-    df_hist = df[df['position'] != 'BENCH'].copy()
+    df_hist = df[df["position"] != "BENCH"].copy()
 
     # Compute historical mean points per (position_group, opponent, game_date)
     # Use dynamic target column name for the aggregation
-    avg_col_name = f'avg_{target_col}_opp_position'
-    
+    avg_col_name = f"avg_{target_col}_opp_position"
+
     # Include season in the grouping for the base aggregation to ensure we have it for the next steps
     df_avg = (
-        df_hist
-        .groupby(['position_group', 'opponent', 'game_date', 'season'], as_index=False)[target_col]
+        df_hist.groupby(
+            ["position_group", "opponent", "game_date", "season"], as_index=False
+        )[target_col]
         .mean()
-        .rename(columns={target_col: 'avg_target'})
+        .rename(columns={target_col: "avg_target"})
     )
 
     # sort chronologically per group (oldest -> newest)
-    df_avg = df_avg.sort_values(['position_group', 'opponent', 'game_date'], ascending=[True, True, True]).reset_index(drop=True)
+    df_avg = df_avg.sort_values(
+        ["position_group", "opponent", "game_date"], ascending=[True, True, True]
+    ).reset_index(drop=True)
 
     # Compute rolling averages shifted by 1 to avoid data leakage
-    
+
     # For last 10 and 20, we keep the cross-season logic (group by position and opponent only)
-    grp_cross_season = df_avg.groupby(['position_group', 'opponent'])['avg_target']
-    
+    grp_cross_season = df_avg.groupby(["position_group", "opponent"])["avg_target"]
+
     # For 'all', we want it to be season-specific as requested
-    grp_season = df_avg.groupby(['position_group', 'opponent', 'season'])['avg_target']
-    
-    col_10 = f'{avg_col_name}_last_10'
-    col_20 = f'{avg_col_name}_last_20'
-    col_all = f'{avg_col_name}_all'
-    
-    df_avg[col_10] = grp_cross_season.apply(lambda x: x.shift(1).rolling(10, min_periods=1).mean()).reset_index(level=[0,1], drop=True)
-    df_avg[col_20] = grp_cross_season.apply(lambda x: x.shift(1).rolling(20, min_periods=1).mean()).reset_index(level=[0,1], drop=True)
-    
+    grp_season = df_avg.groupby(["position_group", "opponent", "season"])["avg_target"]
+
+    col_10 = f"{avg_col_name}_last_10"
+    col_20 = f"{avg_col_name}_last_20"
+    col_all = f"{avg_col_name}_all"
+
+    df_avg[col_10] = grp_cross_season.apply(
+        lambda x: x.shift(1).rolling(10, min_periods=1).mean()
+    ).reset_index(level=[0, 1], drop=True)
+    df_avg[col_20] = grp_cross_season.apply(
+        lambda x: x.shift(1).rolling(20, min_periods=1).mean()
+    ).reset_index(level=[0, 1], drop=True)
+
     # Use the season-specific group for the expanding mean
     # Note: reset_index(level=[0,1,2], drop=True) because grouping has 3 keys
-    df_avg[col_all] = grp_season.apply(lambda x: x.shift(1).expanding().mean()).reset_index(level=[0,1,2], drop=True)
+    df_avg[col_all] = grp_season.apply(
+        lambda x: x.shift(1).expanding().mean()
+    ).reset_index(level=[0, 1, 2], drop=True)
 
     # Merge back by date so each row only sees past info
     final_df = df.merge(
-        df_avg[['position_group', 'opponent', 'game_date',
-                col_10, col_20, col_all]],
-        on=['position_group', 'opponent', 'game_date'],
-        how='left'
+        df_avg[["position_group", "opponent", "game_date", col_10, col_20, col_all]],
+        on=["position_group", "opponent", "game_date"],
+        how="left",
     )
 
     # Fill NaN for first occurrences
     final_df[[col_10, col_20, col_all]] = final_df[[col_10, col_20, col_all]].fillna(0)
-    
+
     return final_df
+
 
 def normalize_features(df: pd.DataFrame, key_stats: Dict[str, str]) -> pd.DataFrame:
     """
     Normalizing by playing time and pace gives features comparable across starters and bench.
-    
+
     Args:
         df (pd.DataFrame): input DataFrame
         key_stats (Dict[str, str]): dictionary of stats to normalize
-        
+
     Returns:
         pd.DataFrame: The DataFrame with normalized features added.
     """
     for stat in key_stats:
         if stat in df.columns:
             per36 = f"{stat}_per36"
-            df[per36] = df[stat] / df['minutes'] * 36
+            df[per36] = df[stat] / df["minutes"] * 36
 
     # And per-possession metrics
     for stat in key_stats:
         if stat in df.columns:
             ppp = f"{stat}_per_poss"
-            df[ppp] = df[stat] / df['possessions'] 
+            df[ppp] = df[stat] / df["possessions"]
 
     return df
 
-def compute_rolling_stats(df: pd.DataFrame, key_stats: Dict[str, str], windows: List[int] = [5,10,20]) -> pd.DataFrame:
+
+def compute_rolling_stats(
+    df: pd.DataFrame, key_stats: Dict[str, str], windows: List[int] = [5, 10, 20]
+) -> pd.DataFrame:
     """
     Compute rolling averages for key stats over specified windows.
-    
+
     Args:
         df (pd.DataFrame): input DataFrame
         key_stats (Dict[str, str]): dictionary of stats to compute rolling averages for
         windows (List[int]): list of window sizes (in number of games)
-        
+
     Returns:
         pd.DataFrame: The DataFrame with rolling average features added.
     """
     # Sort by personId and game_date to ensure correct rolling calculations
-    df = df.sort_values(by=['personId', 'game_date'], ascending=[True, True]).copy()
-    
+    df = df.sort_values(by=["personId", "game_date"], ascending=[True, True]).copy()
+
     # Exclude Engineered stats
-    raw_stats = {k:v for k,v in key_stats.items() if 'engineering' not in v.lower()}
-    
+    raw_stats = {k: v for k, v in key_stats.items() if "engineering" not in v.lower()}
+
     new_features = {}
-    
+
     for period in raw_stats:
         for rolling_period in windows:
             per36 = f"{period}_per36"
             per_poss = f"{period}_per_poss"
-            
+
             if per36 in df.columns:
-                new_features[f"{per36}_rolling_{rolling_period}"] = (df
-                                                           .groupby('personId')[per36]
-                                                           .transform(lambda x: x.shift(1).rolling(rolling_period, min_periods=1)
-                                                                      .mean())
+                new_features[f"{per36}_rolling_{rolling_period}"] = df.groupby(
+                    "personId"
+                )[per36].transform(
+                    lambda x: x.shift(1).rolling(rolling_period, min_periods=1).mean()
                 )
             if per_poss in df.columns:
-                new_features[f"{per_poss}_rolling_{rolling_period}"] = (df
-                                                              .groupby('personId')[per_poss]
-                                                              .transform(lambda x: x.shift(1).rolling(rolling_period, min_periods=1)
-                                                                         .mean())
+                new_features[f"{per_poss}_rolling_{rolling_period}"] = df.groupby(
+                    "personId"
+                )[per_poss].transform(
+                    lambda x: x.shift(1).rolling(rolling_period, min_periods=1).mean()
                 )
-            
+
             # Also compute raw rolling stats (CRITICAL for volume stats like minutes)
             if period in df.columns:
-                new_features[f"{period}_rolling_{rolling_period}"] = (df
-                                                           .groupby('personId')[period]
-                                                           .transform(lambda x: x.shift(1).rolling(rolling_period, min_periods=1)
-                                                                      .mean())
+                new_features[f"{period}_rolling_{rolling_period}"] = df.groupby(
+                    "personId"
+                )[period].transform(
+                    lambda x: x.shift(1).rolling(rolling_period, min_periods=1).mean()
                 )
 
     if new_features:
@@ -232,59 +267,66 @@ def compute_rolling_stats(df: pd.DataFrame, key_stats: Dict[str, str], windows: 
 
     return df
 
-def encode_categorical_features(df: pd.DataFrame, categorical_cols: List[str]) -> Tuple[pd.DataFrame, List[str]]:
+
+def encode_categorical_features(
+    df: pd.DataFrame, categorical_cols: List[str]
+) -> Tuple[pd.DataFrame, List[str]]:
     """
     Encode categorical features using one-hot encoding.
-    
+
     Args:
         df (pd.DataFrame): input DataFrame
         categorical_cols (List[str]): list of categorical columns to encode
-        
+
     Returns:
-        Tuple[pd.DataFrame, List[str], OneHotEncoder]: 
+        Tuple[pd.DataFrame, List[str], OneHotEncoder]:
             - DataFrame with one-hot encoded categorical features added
             - List of new feature names
             - Fitted encoder
     """
     # encode categorical features
-    encoder: OneHotEncoder = OneHotEncoder(sparse_output=False, handle_unknown='ignore')
+    encoder: OneHotEncoder = OneHotEncoder(sparse_output=False, handle_unknown="ignore")
     encoded_categorical: np.ndarray = encoder.fit_transform(df[categorical_cols])
-    
+
     feature_names: Any = encoder.get_feature_names_out(categorical_cols).tolist()
 
     # Drop original categorical columns
     df = df.drop(categorical_cols, axis=1)
 
     # Concatenate encoded columns to original dataframe
-    final_df: pd.DataFrame = pd.concat([df, pd.DataFrame(encoded_categorical, 
-                                           columns=feature_names, 
-                                           index=df.index)], axis=1)
-    
+    final_df: pd.DataFrame = pd.concat(
+        [df, pd.DataFrame(encoded_categorical, columns=feature_names, index=df.index)],
+        axis=1,
+    )
+
     return final_df, feature_names
 
-def get_feature_cols(key_stats: Dict[str, str], rolling_periods: List[int] = [5, 10, 20]) -> List[str]:
+
+def get_feature_cols(
+    key_stats: Dict[str, str], rolling_periods: List[int] = [5, 10, 20]
+) -> List[str]:
     """
     Generate the list of feature columns based on key stats and rolling periods.
-    
+
     Args:
         key_stats (Dict[str, str]): dictionary of stats
         rolling_periods (List[int]): list of rolling window sizes
-        
+
     Returns:
         List[str]: List of feature column names
     """
     feature_cols = []
-    
+
     # Separate raw stats (get rolling) vs engineering stats (get per36/per_poss only)
-    raw_stats = [k for k, v in key_stats.items() if 'raw' in v.lower()]
-    engineering_stats = [k for k, v in key_stats.items() if 'engineering' in v.lower()]
-    
+    raw_stats = [k for k, v in key_stats.items() if "raw" in v.lower()]
+    engineering_stats = [k for k, v in key_stats.items() if "engineering" in v.lower()]
+
     # 1) Add rolling features GROUPED BY WINDOW (matching notebook)
     for window in rolling_periods:
         # First add all _per36_rolling_X for this window
         for stat in raw_stats:
             feature_cols.append(f"{stat}_per36_rolling_{window}")
-        
+
         # Then add all _per_poss_rolling_X for this window
         for stat in raw_stats:
             feature_cols.append(f"{stat}_per_poss_rolling_{window}")
@@ -292,22 +334,23 @@ def get_feature_cols(key_stats: Dict[str, str], rolling_periods: List[int] = [5,
         # Then add all raw rolling stats (e.g. minutes_rolling_5)
         for stat in raw_stats:
             feature_cols.append(f"{stat}_rolling_{window}")
-    
+
     # 2) Add historical averages (engineering stats) - per36 first, then per_poss
     for stat in engineering_stats:
         feature_cols.append(f"{stat}_per36")
-    
+
     for stat in engineering_stats:
         feature_cols.append(f"{stat}_per_poss")
 
     # Add rest_days as a feature
-    feature_cols.append('rest_days')
+    feature_cols.append("rest_days")
 
     return feature_cols
 
-def get_rest_days(players_df: pd.DataFrame,
-                  boxscore_df: pd.DataFrame,
-                  date: datetime.date) -> pd.DataFrame:
+
+def get_rest_days(
+    players_df: pd.DataFrame, boxscore_df: pd.DataFrame, date: datetime.date
+) -> pd.DataFrame:
     """
     Calculate rest days for each players up to a given date.
     Args:
@@ -316,34 +359,37 @@ def get_rest_days(players_df: pd.DataFrame,
         pd.DataFrame: DataFrame with rest_days column added
     """
 
-    # Get unique players 
-    players_unique: pd.DataFrame = players_df[['person_id', 'team_id']].drop_duplicates()
+    # Get unique players
+    players_unique: pd.DataFrame = players_df[
+        ["person_id", "team_id"]
+    ].drop_duplicates()
 
     # Get last game date for each player
     last_games: pd.DataFrame = (
-        boxscore_df[pd.to_datetime(boxscore_df['game_date']).dt.date  < date]
-        .sort_values('game_date')
-        .groupby('personId')
-        .tail(1)[['personId', 'game_date']]
-        .rename(columns={'game_date': 'last_game_date'})
+        boxscore_df[pd.to_datetime(boxscore_df["game_date"]).dt.date < date]
+        .sort_values("game_date")
+        .groupby("personId")
+        .tail(1)[["personId", "game_date"]]
+        .rename(columns={"game_date": "last_game_date"})
     )
 
     # Merge to get last game date per player
     rest_days_df: pd.DataFrame = players_unique.merge(
-        last_games,
-        left_on='person_id',
-        right_on='personId',
-        how='left'
+        last_games, left_on="person_id", right_on="personId", how="left"
     )
 
     # Calculate rest days
-    rest_days_df['rest_days'] = (pd.to_datetime(date) - pd.to_datetime(rest_days_df['last_game_date'])).dt.days
-    rest_days_df['rest_days'] = rest_days_df['rest_days'].fillna(7)  # Default to 7 days if no last game
-    
-    return rest_days_df[['personId', 'rest_days']]
+    rest_days_df["rest_days"] = (
+        pd.to_datetime(date) - pd.to_datetime(rest_days_df["last_game_date"])
+    ).dt.days
+    rest_days_df["rest_days"] = rest_days_df["rest_days"].fillna(
+        7
+    )  # Default to 7 days if no last game
 
-def get_volatility(df_historical: pd.DataFrame, 
-                           target_variable: str) -> pd.DataFrame:
+    return rest_days_df[["personId", "rest_days"]]
+
+
+def get_volatility(df_historical: pd.DataFrame, target_variable: str) -> pd.DataFrame:
     """
     Calculate fantasy points volatility (std dev over last 20 games).
     Args:
@@ -352,32 +398,34 @@ def get_volatility(df_historical: pd.DataFrame,
     Returns:
         pd.DataFrame: DataFrame with personId and fantasy_volatility columns
     """
-    
+
     # Calculate volatility (std dev of fantasy points over last 10 games)
     # We need to do this on the full history before taking the tail
-    df_hist_sorted: pd.DataFrame = df_historical.sort_values(['personId', 'game_date'])
-    df_hist_sorted['fantasy_volatility'] = df_hist_sorted.groupby('personId')[target_variable].transform(
-            lambda x: x.rolling(20, min_periods=5).std()
-        )
-    
+    df_hist_sorted: pd.DataFrame = df_historical.sort_values(["personId", "game_date"])
+    df_hist_sorted["fantasy_volatility"] = df_hist_sorted.groupby("personId")[
+        target_variable
+    ].transform(lambda x: x.rolling(20, min_periods=5).std())
+
     # Get latest volatility values
     volatility_df: pd.DataFrame = (
-        df_hist_sorted.sort_values('game_date')
-        .groupby('personId')
-        .tail(1)[['personId', 'fantasy_volatility']]
+        df_hist_sorted.sort_values("game_date")
+        .groupby("personId")
+        .tail(1)[["personId", "fantasy_volatility"]]
     )
 
     return volatility_df
-    
+
+
 def get_final_df(
-             encoded_df: pd.DataFrame, 
-             volatility_df: pd.DataFrame,
-             future_games: pd.DataFrame,
-             model: Any,
-             feature_names: List[str],
-             encoded_feature_names: List[str],
-             measure_prediction: int,
-             measure_volatility: int) -> pd.DataFrame:
+    encoded_df: pd.DataFrame,
+    volatility_df: pd.DataFrame,
+    future_games: pd.DataFrame,
+    model: Any,
+    feature_names: List[str],
+    encoded_feature_names: List[str],
+    measure_prediction: int,
+    measure_volatility: int,
+) -> pd.DataFrame:
     """
     Prepare final DataFrame for prediction.
     Args:
@@ -396,88 +444,92 @@ def get_final_df(
     final_features: List[str] = feature_names + encoded_feature_names
 
     # Get latest stats
-    latest_stats: pd.DataFrame = encoded_df.sort_values('game_date').groupby('personId').tail(1)
-    
+    latest_stats: pd.DataFrame = (
+        encoded_df.sort_values("game_date").groupby("personId").tail(1)
+    )
+
     # Merge volatility into latest stats
     latest_stats: pd.DataFrame = latest_stats.merge(
-        volatility_df,
-        on='personId',
-        how='left'
+        volatility_df, on="personId", how="left"
     )
-    # Merge 
+    # Merge
     cols_to_merge: list[str] = [c for c in final_features if c in latest_stats.columns]
-    cols_to_merge.append('personId')
-    cols_to_merge.append('fantasy_volatility')
-    
+    cols_to_merge.append("personId")
+    cols_to_merge.append("fantasy_volatility")
+
     # Also add rest_days if it exists in latest_stats (but not in final_features list)
-    if 'rest_days' in latest_stats.columns and 'rest_days' not in cols_to_merge:
-        cols_to_merge.append('rest_days')
+    if "rest_days" in latest_stats.columns and "rest_days" not in cols_to_merge:
+        cols_to_merge.append("rest_days")
 
     # Select only relevant features
     future_games_long: pd.DataFrame = future_games.merge(
         latest_stats[cols_to_merge],
-        left_on='person_id',
-        right_on='personId',
-        how='inner'
+        left_on="person_id",
+        right_on="personId",
+        how="inner",
     )
 
     # Predict - check for rest_days and add it if needed
     available_features = [f for f in final_features if f in future_games_long.columns]
-    
+
     # If rest_days is in final_features but not in future_games_long, add it
-    if 'rest_days' in final_features and 'rest_days' not in future_games_long.columns:
+    if "rest_days" in final_features and "rest_days" not in future_games_long.columns:
         # This shouldn't happen if we merged correctly above, but as a fallback
-        future_games_long['rest_days'] = 3  # default value
-    
+        future_games_long["rest_days"] = 3  # default value
+
     X_pred: pd.DataFrame = future_games_long[final_features].fillna(0)
     # DEBUG: Compare with model's expected features
-    if hasattr(model, 'feature_name_'):
+    if hasattr(model, "feature_name_"):
         model_features = model.feature_name_
         print(f"\n🔍 Feature comparison:")
         print(f"   Model expects: {len(model_features)} features")
         print(f"   We have: {len(X_pred.columns)} features")
-        
+
         # Find missing and extra features
         missing = set(model_features) - set(X_pred.columns)
         extra = set(X_pred.columns) - set(model_features)
-        
+
         if missing:
             print(f"\n❌ MISSING features (in model but not in X_pred):")
             for feat in sorted(missing):
                 print(f"   - {feat}")
-        
+
         if extra:
             print(f"\n➕ EXTRA features (in X_pred but not in model):")
             for feat in sorted(extra):
                 print(f"   - {feat}")
-        
+
         # Reorder X_pred to match model's expected feature order
         X_pred = X_pred.reindex(columns=model_features, fill_value=0)
         print(f"\n✅ Reordered X_pred to match model features")
-    
+
     predictions: Any = model.predict(X_pred)
-    
+
     # Create base DataFrame
-    base_df = pd.DataFrame({
-        'gameId': future_games_long['gameId'].values,
-        'gameDate': future_games_long['gameDate'].values,
-        'teamId': future_games_long['team_id'].values,
-        'opponentId': future_games_long['opponent'].values,
-        'personId': future_games_long['personId'].values,
-        'player_slug': future_games_long['player_slug'].values,
-    })
-    
+    base_df = pd.DataFrame(
+        {
+            "gameId": future_games_long["gameId"].values,
+            "gameDate": future_games_long["gameDate"].values,
+            "teamId": future_games_long["team_id"].values,
+            "opponentId": future_games_long["opponent"].values,
+            "personId": future_games_long["personId"].values,
+            "player_slug": future_games_long["player_slug"].values,
+        }
+    )
+
     # Create predictions rows (narrow format)
     predictions_rows = base_df.copy()
-    predictions_rows['Measure'] = measure_prediction
-    predictions_rows['Predictions'] = np.round(predictions, 1)
-    
+    predictions_rows["Measure"] = measure_prediction
+    predictions_rows["Predictions"] = np.round(predictions, 1)
+
     # Create volatility rows (narrow format)
     volatility_rows = base_df.copy()
-    volatility_rows['Measure'] = measure_volatility
-    volatility_rows['Predictions'] = np.round(future_games_long['fantasy_volatility'].fillna(0), 1)
-    
+    volatility_rows["Measure"] = measure_volatility
+    volatility_rows["Predictions"] = np.round(
+        future_games_long["fantasy_volatility"], 1
+    )
+
     # Combine both measures
     predictions_df = pd.concat([predictions_rows, volatility_rows], ignore_index=True)
-    
+
     return predictions_df

--- a/common/io_utils.py
+++ b/common/io_utils.py
@@ -1,6 +1,7 @@
 """
 This module contains the common variables and functions used in the NBA Stats Data Pipeline to store and load data.
 """
+
 import os
 import re
 import pandas as pd
@@ -12,29 +13,31 @@ from typing import Optional, Iterable
 from google.api_core.exceptions import NotFound, BadRequest
 
 # Define the names of the files to be used in the databases folder.
-AdvancedBoxscoreFileName: str = "nba_boxscore_advanced" 
+AdvancedBoxscoreFileName: str = "nba_boxscore_advanced"
 BoxscoreFileName: str = "nba_boxscore_basic"
 PlayersFileName: str = "nba_players_df"
 TeamsFileName: str = "nba_teams_df"
 FutureGamesFileName: str = "nba_future_games_df"
-PredictionsFileName: str = 'nba_predictions_df'
-ScheduleFileName: str = 'nba_schedule_df' 
-MetricsFileName: str = 'model_training_metrics_df'
+PredictionsFileName: str = "nba_predictions_df"
+ScheduleFileName: str = "nba_schedule_df"
+MetricsFileName: str = "model_training_metrics_df"
+# Availability subsystem
+InjuryReportFileName: str = "nba_injury_report"  # raw parsed PDF rows
+AvailabilityFileName: str = "nba_player_availability"  # enriched downstream table
 
 # Define the path to the databases folder.
 databases_path: str = "databases/"
 PROJECT_ID = "ml-nba-project"
 DATASET_ID = "nba_dataset"
 
+
 def _table_ref(table_name: str) -> str:
     return f"{PROJECT_ID}.{DATASET_ID}.{table_name}"
 
-from google.cloud import bigquery
-from google.api_core.exceptions import NotFound
-import pandas as pd
-from typing import Iterable
 
-def _delete_rows_by_game_id(client: bigquery.Client, table_id: str, game_ids: Iterable) -> int:
+def _delete_rows_by_game_id(
+    client: bigquery.Client, table_id: str, game_ids: Iterable
+) -> int:
     game_ids = list({str(gid) for gid in game_ids if pd.notna(gid)})
     if not game_ids:
         return 0
@@ -64,9 +67,7 @@ def _delete_rows_by_game_id(client: bigquery.Client, table_id: str, game_ids: It
 
 
 def _delete_predictions_by_composite_key(
-    client: bigquery.Client, 
-    table_id: str, 
-    df: pd.DataFrame
+    client: bigquery.Client, table_id: str, df: pd.DataFrame
 ) -> int:
     """
     Delete existing predictions matching gameId + personId + Measure combination.
@@ -74,29 +75,29 @@ def _delete_predictions_by_composite_key(
     """
     if df.empty:
         return 0
-    
+
     # Check if table exists
     try:
         client.get_table(table_id)
     except NotFound:
         print(f"Table {table_id} not found, skipping deletion")
         return 0
-    
+
     # Build composite keys from new predictions
-    required_cols = ['gameId', 'personId', 'Measure']
+    required_cols = ["gameId", "personId", "Measure"]
     if not all(col in df.columns for col in required_cols):
         print(f"⚠️ Missing required columns for deletion: {required_cols}")
         return 0
-    
+
     # Create a temporary table with the keys to delete
     # Match BigQuery schema: gameId=STRING, personId=INTEGER, Measure=INTEGER
     keys_df = df[required_cols].drop_duplicates()
-    keys_df['gameId'] = keys_df['gameId'].astype(str)
-    keys_df['personId'] = keys_df['personId'].astype('Int64')  # Nullable integer
-    keys_df['Measure'] = keys_df['Measure'].astype('Int64')
-    
+    keys_df["gameId"] = keys_df["gameId"].astype(str)
+    keys_df["personId"] = keys_df["personId"].astype("Int64")  # Nullable integer
+    keys_df["Measure"] = keys_df["Measure"].astype("Int64")
+
     temp_table_id = f"{table_id}_delete_keys_temp"
-    
+
     # Upload keys to temp table with explicit schema matching target table
     job_config = bigquery.LoadJobConfig(
         write_disposition="WRITE_TRUNCATE",
@@ -104,10 +105,12 @@ def _delete_predictions_by_composite_key(
             bigquery.SchemaField("gameId", "STRING"),
             bigquery.SchemaField("personId", "INTEGER"),
             bigquery.SchemaField("Measure", "INTEGER"),
-        ]
+        ],
     )
-    client.load_table_from_dataframe(keys_df, temp_table_id, job_config=job_config).result()
-    
+    client.load_table_from_dataframe(
+        keys_df, temp_table_id, job_config=job_config
+    ).result()
+
     # Delete matching rows using JOIN
     query = f"""
     DELETE FROM `{table_id}` AS target
@@ -120,10 +123,10 @@ def _delete_predictions_by_composite_key(
     """
     job = client.query(query)
     job.result()
-    
+
     # Clean up temp table
     client.delete_table(temp_table_id, not_found_ok=True)
-    
+
     deleted_count = getattr(job, "num_dml_affected_rows", 0) or 0
     return deleted_count
 
@@ -164,7 +167,9 @@ def save_database(
     if has_game_id and write_disposition == "WRITE_APPEND":
         unique_ids = df["gameId"].astype(str).dropna().unique().tolist()
         deleted = _delete_rows_by_game_id(client, table_id, unique_ids)
-        print(f"🧹 Deleted {deleted} rows in {table_id} for {len(unique_ids)} gameId(s).")
+        print(
+            f"🧹 Deleted {deleted} rows in {table_id} for {len(unique_ids)} gameId(s)."
+        )
 
         load_config = bigquery.LoadJobConfig(
             write_disposition="WRITE_APPEND",
@@ -185,20 +190,18 @@ def save_database(
             print(f" - {err.get('message')}")
         raise
 
-    print(f"✅ Saved {len(df):,} row(s) to {table_id} "
-          f"({'APPEND after delete-by-key' if has_game_id else load_config.write_disposition})")
+    print(
+        f"✅ Saved {len(df):,} row(s) to {table_id} "
+        f"({'APPEND after delete-by-key' if has_game_id else load_config.write_disposition})"
+    )
 
 
-def save_predictions(
-    df: pd.DataFrame,
-    table_name: str,
-    mode: str = "bq"
-) -> None:
+def save_predictions(df: pd.DataFrame, table_name: str, mode: str = "bq") -> None:
     """
     Save predictions with intelligent append logic.
     Deletes existing predictions for the same gameId + personId + Measure combination
     before appending new predictions. Works in both local and BigQuery modes.
-    
+
     Args:
         df (pd.DataFrame): Predictions DataFrame with columns: gameId, personId, Measure, Predictions, etc.
         table_name (str): Table name (e.g., 'nba_predictions_df')
@@ -207,30 +210,42 @@ def save_predictions(
     if df is None or df.empty:
         print("⚠️ Predictions DataFrame empty; nothing to save.")
         return
-    
+
     # Add audit timestamp
     df["aud_modification_date"] = pd.Timestamp.now(tz="Europe/Madrid")
-    
+
     if mode == "local":
         # Local mode: load existing, filter out duplicates, append new
         path = f"databases/{table_name}.csv"
-        
+
         if os.path.exists(path):
             existing_df = pd.read_csv(path, low_memory=False)
-            
+
             # Remove existing predictions for same gameId + personId + Measure
-            if not existing_df.empty and all(col in existing_df.columns for col in ['gameId', 'personId', 'Measure']):
+            if not existing_df.empty and all(
+                col in existing_df.columns for col in ["gameId", "personId", "Measure"]
+            ):
                 # Create composite key for filtering
-                new_keys = df[['gameId', 'personId', 'Measure']].astype(str).agg('_'.join, axis=1)
-                existing_keys = existing_df[['gameId', 'personId', 'Measure']].astype(str).agg('_'.join, axis=1)
-                
+                new_keys = (
+                    df[["gameId", "personId", "Measure"]]
+                    .astype(str)
+                    .agg("_".join, axis=1)
+                )
+                existing_keys = (
+                    existing_df[["gameId", "personId", "Measure"]]
+                    .astype(str)
+                    .agg("_".join, axis=1)
+                )
+
                 # Keep only rows from existing that don't match new predictions
                 mask = ~existing_keys.isin(new_keys)
                 filtered_existing = existing_df[mask]
-                
+
                 deleted_count = len(existing_df) - len(filtered_existing)
-                print(f"🧹 Removed {deleted_count} existing predictions for {len(new_keys.unique())} game-player-measure combinations.")
-                
+                print(
+                    f"🧹 Removed {deleted_count} existing predictions for {len(new_keys.unique())} game-player-measure combinations."
+                )
+
                 # Concatenate filtered existing with new
                 final_df = pd.concat([filtered_existing, df], ignore_index=True)
             else:
@@ -239,28 +254,29 @@ def save_predictions(
         else:
             # No existing file
             final_df = df
-        
+
         final_df.to_csv(path, index=False)
-        print(f"✅ Saved {len(df):,} new prediction(s) to {path} (Total: {len(final_df):,} rows)")
+        print(
+            f"✅ Saved {len(df):,} new prediction(s) to {path} (Total: {len(final_df):,} rows)"
+        )
         return
-    
+
     if mode != "bq":
         raise ValueError("Invalid mode: choose 'local' or 'bq'")
-    
+
     # BigQuery mode
     client = bigquery.Client()
     table_id = _table_ref(table_name)
-    
+
     # Delete existing predictions for same composite keys
     deleted = _delete_predictions_by_composite_key(client, table_id, df)
     print(f"🧹 Deleted {deleted} existing predictions for {len(df)} new prediction(s).")
-    
+
     # Append new predictions
     load_config = bigquery.LoadJobConfig(
-        write_disposition="WRITE_APPEND",
-        autodetect=True
+        write_disposition="WRITE_APPEND", autodetect=True
     )
-    
+
     job = client.load_table_from_dataframe(df, table_id, job_config=load_config)
     try:
         job.result()
@@ -269,11 +285,13 @@ def save_predictions(
         for err in getattr(job, "errors", []) or []:
             print(f" - {err.get('message')}")
         raise
-    
-    print(f"✅ Saved {len(df):,} prediction(s) to {table_id} (APPEND after delete-by-composite-key)")
+
+    print(
+        f"✅ Saved {len(df):,} prediction(s) to {table_id} (APPEND after delete-by-composite-key)"
+    )
 
 
-def load_data(FileName: str, mode: str ) -> pd.DataFrame:
+def load_data(FileName: str, mode: str) -> pd.DataFrame:
     """
     Load data either locally or to BigQuery, depending on mode
     Args:
@@ -286,7 +304,7 @@ def load_data(FileName: str, mode: str ) -> pd.DataFrame:
         path: str = f"{databases_path}{FileName}.csv"
         if os.path.exists(path):
             try:
-                df: pd.DataFrame = pd.read_csv(path,low_memory=False)
+                df: pd.DataFrame = pd.read_csv(path, low_memory=False)
                 return df
             except Exception as e:
                 print(f"Error loading local file {path}: {e}")
@@ -301,6 +319,8 @@ def load_data(FileName: str, mode: str ) -> pd.DataFrame:
         except Exception as e:
             print(f"❌ Could not load existing data from BigQuery: {e}")
             return pd.DataFrame()
+    return pd.DataFrame()
+
 
 def _parse_gcs_uri(uri: str) -> tuple[str, str]:
     m = re.match(r"^gs://([^/]+)/(.+)$", uri)

--- a/common/utils.py
+++ b/common/utils.py
@@ -1,6 +1,7 @@
 """
 This module contains common utility functions for NBA data processing.
 """
+
 import time
 import logging
 import pandas as pd
@@ -25,7 +26,9 @@ def build_proxy_url(proxy_user: str, proxy_pass: str) -> str | None:
     """
     if not proxy_user or not proxy_pass:
         return None
-    return f"http://{quote(proxy_user, safe='')}:{quote(proxy_pass, safe='')}@{PROXY_HOST}"
+    return (
+        f"http://{quote(proxy_user, safe='')}:{quote(proxy_pass, safe='')}@{PROXY_HOST}"
+    )
 
 
 def get_retry_session(proxy_url: str | None = None) -> requests.Session:
@@ -38,7 +41,7 @@ def get_retry_session(proxy_url: str | None = None) -> requests.Session:
     session = requests.Session()
     retry = Retry(
         total=3,
-        backoff_factor=2,           # waits 2 s, 4 s, 8 s between retries
+        backoff_factor=2,  # waits 2 s, 4 s, 8 s between retries
         status_forcelist=list(_RETRY_STATUS),
         allowed_methods=["GET"],
         raise_on_status=False,
@@ -51,7 +54,9 @@ def get_retry_session(proxy_url: str | None = None) -> requests.Session:
     return session
 
 
-def call_nba_api_with_retry(fn, *args, max_retries: int = 3, backoff: float = 2.0, **kwargs):
+def call_nba_api_with_retry(
+    fn, *args, max_retries: int = 3, backoff: float = 2.0, **kwargs
+):
     """
     Call any zero-argument callable (or callable fn(*args, **kwargs)) that
     wraps an nba_api endpoint, retrying on transient ProxyError / timeout.
@@ -70,18 +75,34 @@ def call_nba_api_with_retry(fn, *args, max_retries: int = 3, backoff: float = 2.
             last_exc = exc
             err_str = str(exc)
             # Only retry on transient network / proxy errors
-            transient = any(kw in err_str for kw in (
-                "522", "524", "ProxyError", "ReadTimeoutError",
-                "ConnectionError", "RemoteDisconnected", "Read timed out",
-            ))
+            transient = any(
+                kw in err_str
+                for kw in (
+                    "522",
+                    "524",
+                    "ProxyError",
+                    "ReadTimeoutError",
+                    "ConnectionError",
+                    "RemoteDisconnected",
+                    "Read timed out",
+                )
+            )
             if not transient or attempt == max_retries:
                 logger.error("[retry] Non-retryable or max retries reached: %s", exc)
                 raise
-            wait = backoff ** attempt
-            logger.warning("[retry] Attempt %d/%d failed (%s). Retrying in %.0fs...",
-                           attempt, max_retries, exc.__class__.__name__, wait)
+            wait = backoff**attempt
+            logger.warning(
+                "[retry] Attempt %d/%d failed (%s). Retrying in %.0fs...",
+                attempt,
+                max_retries,
+                exc.__class__.__name__,
+                wait,
+            )
             time.sleep(wait)
-    raise last_exc  # unreachable, satisfies type checkers
+    if last_exc is not None:
+        raise last_exc
+    raise RuntimeError("Retry loop exited without returning or raising")
+
 
 # Function to extract season from game_id
 def extract_season(game_id):
@@ -98,26 +119,27 @@ def extract_season(game_id):
         if len(str(game_id)) == 8:
             gid = str(game_id)[1:3]
             return int(gid) + 2000
-        
-        if game_id.startswith('00'):
+
+        if game_id.startswith("00"):
             gid = game_id[3:5]
             return int(gid) + 2000
     except Exception:
         return np.nan
+
 
 # Function to transform minutes from string to float
 def parse_minutes(val):
     """
     Convert 'MM:SS' or 'H:MM:SS' to minutes (float).
     Args:
-        val (str or float): The minutes string or numeric value.    
+        val (str or float): The minutes string or numeric value.
         Returns:
             float: The total minutes as a float.
     """
-    if pd.isna(val) or val == '':
+    if pd.isna(val) or val == "":
         return 0.0
     try:
-        parts = str(val).split(':')
+        parts = str(val).split(":")
         if len(parts) == 2:  # MM:SS
             m, s = map(int, parts)
             return m + s / 60

--- a/jenkins/Jenkins.Dockerfile
+++ b/jenkins/Jenkins.Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
     python3-venv \
     git \
     build-essential \
+    libgomp1 \
  && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
  && apt-get update && apt-get install -y docker-ce-cli

--- a/main.py
+++ b/main.py
@@ -3,12 +3,20 @@ import argparse
 import os
 import sys
 import logging
+from io import TextIOWrapper
 
 # Force UTF-8 stdout/stderr on Windows so emoji in print() don't crash.
-if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
-    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
-if sys.stderr.encoding and sys.stderr.encoding.lower() not in ("utf-8", "utf8"):
-    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+def _force_utf8_stream(stream: object) -> None:
+    if not isinstance(stream, TextIOWrapper):
+        return
+
+    encoding = stream.encoding or ""
+    if encoding.lower() not in ("utf-8", "utf8"):
+        stream.reconfigure(encoding="utf-8", errors="replace")
+
+
+_force_utf8_stream(sys.stdout)
+_force_utf8_stream(sys.stderr)
 
 from src.data_collectors.get_nba_boxscore_basic import BoxscoreGames
 from src.data_collectors.get_nba_players import NbaPlayersData

--- a/main.py
+++ b/main.py
@@ -1,14 +1,22 @@
 from datetime import datetime
 import argparse
 import os
-import logging
 import sys
+import logging
+
+# Force UTF-8 stdout/stderr on Windows so emoji in print() don't crash.
+if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if sys.stderr.encoding and sys.stderr.encoding.lower() not in ("utf-8", "utf8"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
 
 from src.data_collectors.get_nba_boxscore_basic import BoxscoreGames
 from src.data_collectors.get_nba_players import NbaPlayersData
 from src.data_collectors.get_nba_teams import NbaTeamsData
 from src.data_collectors.get_nba_schedule import ScheduleData
 from src.data_collectors.get_nba_advanced_boxscore import AdvancedBoxscoreGames
+from src.data_collectors.get_injury_report import InjuryReportCollector
+from src.availability.availability_table import AvailabilityTableBuilder
 from src.predictors.unified_predictor import UnifiedPredictor
 from src.training.train import UnifiedModelTrainer
 from common.parser import build_parser
@@ -17,83 +25,131 @@ from common.parser import build_parser
 def main():
     time_start = datetime.today()
 
-    parser:argparse.ArgumentParser = argparse.ArgumentParser(description="NBA Stats Data Pipeline")
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(
+        description="NBA Stats Data Pipeline"
+    )
 
-    process_name, current_season, save_mode, season_type, date, model_path, target, tune_params = build_parser(parser)
+    (
+        process_name,
+        current_season,
+        save_mode,
+        season_type,
+        date,
+        model_path,
+        target,
+        tune_params,
+    ) = build_parser(parser)
 
-    valid_processes: list[str] = ["get_nba_players",
-                                  "get_nba_teams", 
-                                  "get_nba_schedule",
-                                  "get_nba_boxscore_basic",  
-                                  "get_nba_advanced_boxscore",
-                                  "train",
-                                  "get_predictions_stats_points",
-                                  "get_predictions_fantasy_points"]
+    valid_processes: list[str] = [
+        "get_nba_players",
+        "get_nba_teams",
+        "get_nba_schedule",
+        "get_nba_boxscore_basic",
+        "get_nba_advanced_boxscore",
+        "get_injury_report",
+        "compute_availability",
+        "train",
+        "get_predictions_stats_points",
+        "get_predictions_fantasy_points",
+    ]
 
     # Strip whitespace and check for validity
     process_name = process_name.strip()
-        
+
     # Check if the process name is valid
     if process_name not in valid_processes:
-        logging.error(f"Invalid process name: {process_name}. Valid processes are: {valid_processes}")
-        raise Exception(f"Invalid process name: {process_name}. Valid processes are: {valid_processes}")
+        logging.error(
+            f"Invalid process name: {process_name}. Valid processes are: {valid_processes}"
+        )
+        raise Exception(
+            f"Invalid process name: {process_name}. Valid processes are: {valid_processes}"
+        )
 
     # Execute the process
     elif process_name == "get_nba_players":
         print(f"Running process: {process_name} with season: {current_season}")
-        NbaPlayersData( current_season=current_season, 
-                        save_mode=save_mode,  
-                        proxy_user=os.getenv("NBA_PROXY_USER"),  
-                        proxy_pass=os.getenv("NBA_PROXY_PASS")
-                        ).run()
+        NbaPlayersData(
+            current_season=current_season,
+            save_mode=save_mode,
+            proxy_user=os.getenv("NBA_PROXY_USER"),
+            proxy_pass=os.getenv("NBA_PROXY_PASS"),
+        ).run()
 
     elif process_name == "get_nba_teams":
         print(f"Running process: {process_name} with season: {current_season}")
         NbaTeamsData(save_mode=save_mode).run()
-    
+
     elif process_name == "get_nba_boxscore_basic":
         print(f"Running process: {process_name} with season: {current_season}")
-        BoxscoreGames(  current_season, 
-                        save_mode=save_mode,
-                        proxy_user=os.getenv("NBA_PROXY_USER"),  
-                        proxy_pass=os.getenv("NBA_PROXY_PASS")
-                        ).run()
+        BoxscoreGames(
+            current_season,
+            save_mode=save_mode,
+            proxy_user=os.getenv("NBA_PROXY_USER"),
+            proxy_pass=os.getenv("NBA_PROXY_PASS"),
+        ).run()
     elif process_name == "get_nba_schedule":
         print(f"Running process: {process_name} with season: {current_season}")
-        ScheduleData(current_season=current_season, 
-                     save_mode=save_mode,
-                     proxy_user=os.getenv("NBA_PROXY_USER"),  
-                     proxy_pass=os.getenv("NBA_PROXY_PASS")
-                     ).run()
-            
+        ScheduleData(
+            current_season=current_season,
+            save_mode=save_mode,
+            proxy_user=os.getenv("NBA_PROXY_USER"),
+            proxy_pass=os.getenv("NBA_PROXY_PASS"),
+        ).run()
+
     elif process_name == "get_nba_advanced_boxscore":
         print(f"Running process: {process_name} with season: {current_season}")
-        AdvancedBoxscoreGames(  current_season, 
-                                save_mode=save_mode,
-                                proxy_user=os.getenv("NBA_PROXY_USER"),  
-                                proxy_pass=os.getenv("NBA_PROXY_PASS") 
-                                ).run()
-    
+        AdvancedBoxscoreGames(
+            current_season,
+            save_mode=save_mode,
+            proxy_user=os.getenv("NBA_PROXY_USER"),
+            proxy_pass=os.getenv("NBA_PROXY_PASS"),
+        ).run()
+
+    elif process_name == "get_injury_report":
+        print(f"Running process: {process_name} with date: {date}")
+        InjuryReportCollector(
+            save_mode=save_mode,
+            report_date=date,
+        ).run()
+
+    elif process_name == "compute_availability":
+        print(f"Running process: {process_name} with date: {date}")
+        AvailabilityTableBuilder(
+            save_mode=save_mode,
+            report_date=date,
+        ).run()
+
     elif process_name == "train":
         for tgt in target:
-                print(f"Running process: {process_name} for target: {tgt} (tune_params={tune_params})")
-                UnifiedModelTrainer(
-                    target=tgt,
-                    model_path=model_path,
-                    save_mode=save_mode
-                ).run(tune_params=tune_params)
-        
+            print(
+                f"Running process: {process_name} for target: {tgt} (tune_params={tune_params})"
+            )
+            UnifiedModelTrainer(
+                target=tgt, model_path=model_path, save_mode=save_mode
+            ).run(tune_params=tune_params)
+
     elif process_name == "get_predictions_stats_points":
-        print(f"Running process: {process_name} with date: {date} and model path:{model_path}")
-        UnifiedPredictor(target='points', save_mode=save_mode, date=date, model_path=model_path).run()
+        print(
+            f"Running process: {process_name} with date: {date} and model path:{model_path}"
+        )
+        UnifiedPredictor(
+            target="points", save_mode=save_mode, date=date, model_path=model_path
+        ).run()
 
     elif process_name == "get_predictions_fantasy_points":
-        print(f"Running process: {process_name} with date: {date} and model path:{model_path}")
-        UnifiedPredictor(target='fantasy_points', save_mode=save_mode, date=date, model_path=model_path).run()
-        
-    # print the time taken to run the process    
+        print(
+            f"Running process: {process_name} with date: {date} and model path:{model_path}"
+        )
+        UnifiedPredictor(
+            target="fantasy_points",
+            save_mode=save_mode,
+            date=date,
+            model_path=model_path,
+        ).run()
+
+    # print the time taken to run the process
     print(f"Process {process_name} completed in {datetime.today() - time_start}.")
-    
+
 
 if __name__ == "__main__":
     """
@@ -103,5 +159,5 @@ if __name__ == "__main__":
         main()
     except Exception as e:
         logging.error("Failed to execute the process")
-        logging.error(e,exc_info=True)
+        logging.error(e, exc_info=True)
         sys.exit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ google-cloud-bigquery>=3.10.0
 google-cloud-bigquery-storage>=2.25.0
 pandas-gbq>=0.26.1
 db-dtypes>=1.2.0
+pdfplumber>=0.11.0
+requests>=2.31.0
+pytest>=7.3.0

--- a/scripts/run_all.sh
+++ b/scripts/run_all.sh
@@ -25,17 +25,6 @@ PY
 )"
 fi
 
-# If DATE not provided, use "today" in Europe/Madrid
-if [ -z "${DATE:-}" ]; then
-  DATE="$(python - <<'PY'
-from datetime import datetime
-from zoneinfo import ZoneInfo
-z = ZoneInfo("Europe/Madrid")
-print(datetime.now(z).date().isoformat())
-PY
-)"
-fi
-
 # ---- helpers ----
 ts() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
 log() { echo "[$(ts)] $*"; }
@@ -74,6 +63,14 @@ log "✅ Finished get_nba_boxscore_basic"
 log "➡️ Running get_nba_advanced_boxscore..."
 python main.py -p get_nba_advanced_boxscore -s "$SEASON" -st "$SEASON_TYPE" -sm "$SAVE_MODE"
 log "✅ Finished get_nba_advanced_boxscore"
+
+log "➡️ Running get_injury_report..."
+python main.py -p get_injury_report -sm "$SAVE_MODE" -d "$DATE"
+log "✅ Finished get_injury_report"
+
+log "➡️ Running compute_availability..."
+python main.py -p compute_availability -sm "$SAVE_MODE" -d "$DATE"
+log "✅ Finished compute_availability"
 
 log "➡️ Running train..."
 # Convert space-separated targets to individual arguments

--- a/src/availability/__init__.py
+++ b/src/availability/__init__.py
@@ -1,0 +1,1 @@
+# availability sub-package

--- a/src/availability/availability_table.py
+++ b/src/availability/availability_table.py
@@ -12,7 +12,7 @@ Output schema (one row per player per game date):
     team_id          : int   (NBA team ID, joined from players table)
     person_id        : int   (NBA player ID, joined from players table)
     player_slug      : str
-    player_name_raw  : str   (Lastname,Firstname as in the PDF)
+    player_name      : str   (human-readable display name, e.g. "LeBron James")
     raw_status       : str   (original PDF string)
     status           : str   (canonical: Out|Doubtful|Questionable|Probable|Available)
     reason           : str   (injury description)
@@ -221,7 +221,20 @@ class AvailabilityTableBuilder(metaclass=SingletonMeta):
         all_players_base["report_date"] = self.report_date.strftime("%m/%d/%Y")
         all_players_base["matchup"] = ""
         all_players_base["team"] = all_players_base["team_abbreviation"]
-        all_players_base["player_name"] = all_players_base["player_name_key"]
+        # Use human-readable "First Last" name for healthy baseline rows so
+        # formatting is consistent with injured rows (which carry the raw PDF name).
+        # player_name_key (LAST,FIRST uppercase) is kept only as an internal join key.
+        if {"player_first_name", "player_last_name"}.issubset(all_players_base.columns):
+            all_players_base["player_name"] = (
+                all_players_base["player_first_name"].fillna("").astype(str).str.strip()
+                + " "
+                + all_players_base["player_last_name"]
+                .fillna("")
+                .astype(str)
+                .str.strip()
+            ).str.strip()
+        else:
+            all_players_base["player_name"] = all_players_base["player_name_key"]
         all_players_base["raw_status"] = "Available"
         all_players_base["status"] = "Available"
         all_players_base["reason"] = ""

--- a/src/availability/availability_table.py
+++ b/src/availability/availability_table.py
@@ -1,0 +1,276 @@
+"""
+Availability Table Builder
+==========================
+Combines the raw injury report with the NBA players roster to produce the
+clean, downstream-ready **player availability table** consumed by the win-
+probability, player-props, and team-strength models.
+
+Output schema (one row per player per game date):
+    game_date        : date
+    matchup          : str   (e.g. "MIL@BOS")
+    team             : str   (team abbreviation from injury report)
+    team_id          : int   (NBA team ID, joined from players table)
+    person_id        : int   (NBA player ID, joined from players table)
+    player_slug      : str
+    player_name_raw  : str   (Lastname,Firstname as in the PDF)
+    raw_status       : str   (original PDF string)
+    status           : str   (canonical: Out|Doubtful|Questionable|Probable|Available)
+    reason           : str   (injury description)
+    play_probability : float (prior probability the player will play)
+    is_available     : bool  (True when play_probability >= threshold)
+
+Players NOT listed in the injury report are assumed fully Available (prob=0.97).
+
+Public API
+----------
+    AvailabilityTableBuilder(save_mode, report_date, availability_threshold)
+    .run() -> pd.DataFrame
+"""
+
+import re
+import logging
+import datetime
+import pandas as pd
+
+from common.singleton_meta import SingletonMeta
+from common.io_utils import (
+    InjuryReportFileName,
+    AvailabilityFileName,
+    PlayersFileName,
+    load_data,
+    save_database,
+)
+from common.constants import (
+    AVAILABILITY_PLAY_PROBABILITY,
+    AVAILABILITY_DEFAULT_THRESHOLD,
+)
+from src.availability.injury_normalizer import normalize_report
+
+logger = logging.getLogger(__name__)
+
+
+class AvailabilityTableBuilder(metaclass=SingletonMeta):
+    """
+    Reads the stored injury report + the players roster, enriches with
+    play-probability scores, and saves the final availability table.
+
+    Args:
+        save_mode  (str):   "local" or "bq".
+        report_date (str):  ISO date "YYYY-MM-DD" (defaults to today UTC).
+        availability_threshold (float): Minimum play_probability to mark a
+            player as is_available=True (default from constants).
+    """
+
+    def __init__(
+        self,
+        save_mode: str = "local",
+        report_date: str | None = None,
+        availability_threshold: float | None = None,
+    ) -> None:
+        self.save_mode = save_mode
+        if report_date:
+            self.report_date = datetime.datetime.strptime(
+                report_date, "%Y-%m-%d"
+            ).date()
+        else:
+            self.report_date = datetime.datetime.utcnow().date()
+
+        self.threshold = (
+            availability_threshold
+            if availability_threshold is not None
+            else AVAILABILITY_DEFAULT_THRESHOLD
+        )
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def run(self) -> pd.DataFrame:
+        """
+        Full pipeline: load → enrich → save.
+
+        Returns:
+            Availability DataFrame ready for downstream consumption.
+        """
+        logger.info(f"Building availability table for {self.report_date} …")
+
+        injury_df = load_data(InjuryReportFileName, mode=self.save_mode)
+        players_df = load_data(PlayersFileName, mode=self.save_mode)
+
+        availability_df = self._build(injury_df, players_df)
+
+        if availability_df.empty:
+            logger.warning("Availability table is empty — nothing to save.")
+            return availability_df
+
+        save_database(
+            availability_df,
+            AvailabilityFileName,
+            mode=self.save_mode,
+            write_disposition="WRITE_TRUNCATE",
+        )
+        logger.info(
+            f"Availability table saved ({len(availability_df)} rows) "
+            f"via mode={self.save_mode}"
+        )
+        return availability_df
+
+    # ------------------------------------------------------------------
+    # Core build logic
+    # ------------------------------------------------------------------
+
+    def _build(
+        self,
+        injury_df: pd.DataFrame,
+        players_df: pd.DataFrame,
+    ) -> pd.DataFrame:
+        """
+        Join injury report with players roster, fill missing players as
+        Available, and produce the final table.
+        """
+        if players_df.empty:
+            logger.error(
+                "Players DataFrame is empty — cannot build availability table."
+            )
+            return pd.DataFrame()
+
+        # ---- 1. Normalise the raw injury report ----
+        if injury_df.empty:
+            logger.warning(
+                "Injury report is empty — treating all players as Available."
+            )
+            normalized_injury = pd.DataFrame()
+        else:
+            normalized_injury = normalize_report(injury_df)
+
+        # ---- 2. Prepare players lookup ----
+        # Standardise column names from nba_players_df (lowercase from get_nba_players)
+        players_lookup = (
+            players_df[
+                [
+                    "person_id",
+                    "player_slug",
+                    "team_id",
+                    "team_abbreviation",
+                    "player_last_name",
+                    "player_first_name",
+                ]
+            ]
+            .drop_duplicates(subset=["person_id"])
+            .copy()
+        )
+
+        # Build "Lastname,Firstname" key to match the PDF format
+        players_lookup["player_name_key"] = (
+            players_lookup["player_last_name"].str.strip().str.upper()
+            + ","
+            + players_lookup["player_first_name"].str.strip().str.upper()
+        )
+
+        # ---- 3. Merge injury records onto players ----
+        if not normalized_injury.empty:
+            # Upper-case the name key in injury data for joining.
+            # The NBA PDF compresses suffixes: "PorterJr." instead of "Porter Jr.",
+            # "WilliamsIII" instead of "Williams III", etc.  Insert the missing
+            # space so the key matches the players table's "PORTER JR.,KEVIN" form.
+            _suffix_pat = re.compile(r"([A-Za-z])(Jr\.|Sr\.|II|III|IV)(?=,)")
+            normalized_injury["player_name_key"] = (
+                normalized_injury["player_name"]
+                .str.strip()
+                .apply(lambda n: _suffix_pat.sub(r"\1 \2", n))
+                .str.upper()
+            )
+
+            injured_merged = players_lookup.merge(
+                normalized_injury[
+                    [
+                        "report_date",
+                        "matchup",
+                        "team",
+                        "player_name_key",
+                        "player_name",
+                        "raw_status",
+                        "status",
+                        "reason",
+                        "play_probability",
+                    ]
+                ],
+                on="player_name_key",
+                how="inner",
+            )
+
+            # Warn about injury-report players that have no roster entry
+            matched_keys = set(injured_merged["player_name_key"])
+            unmatched = normalized_injury[
+                ~normalized_injury["player_name_key"].isin(matched_keys)
+            ]
+            if not unmatched.empty:
+                names = unmatched["player_name"].tolist()
+                logger.warning(
+                    "%d player(s) in the injury report have no roster entry "
+                    "(G-League / two-way / not yet rostered) — skipped: %s",
+                    len(names),
+                    ", ".join(names),
+                )
+        else:
+            injured_merged = pd.DataFrame()
+
+        # ---- 4. Build the "all players" baseline — every player is Available ----
+        default_prob = AVAILABILITY_PLAY_PROBABILITY["Available"]
+        all_players_base = players_lookup.copy()
+        all_players_base["report_date"] = self.report_date.strftime("%m/%d/%Y")
+        all_players_base["matchup"] = ""
+        all_players_base["team"] = all_players_base["team_abbreviation"]
+        all_players_base["player_name"] = all_players_base["player_name_key"]
+        all_players_base["raw_status"] = "Available"
+        all_players_base["status"] = "Available"
+        all_players_base["reason"] = ""
+        all_players_base["play_probability"] = default_prob
+
+        # ---- 5. Override baseline with injury records ----
+        if not injured_merged.empty:
+            # Players that appear in the injury report
+            injured_person_ids = set(injured_merged["person_id"].unique())
+
+            # Keep baseline only for players NOT in the injury report
+            clean_players = all_players_base[
+                ~all_players_base["person_id"].isin(injured_person_ids)
+            ]
+
+            combined = pd.concat(
+                [injured_merged, clean_players],
+                ignore_index=True,
+            )
+        else:
+            combined = all_players_base
+
+        # ---- 6. Final column selection + is_available flag ----
+        combined["game_date"] = pd.to_datetime(self.report_date)
+        combined["is_available"] = combined["play_probability"] >= self.threshold
+
+        output_cols = [
+            "game_date",
+            "matchup",
+            "team",
+            "team_id",
+            "person_id",
+            "player_slug",
+            "player_name",
+            "raw_status",
+            "status",
+            "reason",
+            "play_probability",
+            "is_available",
+        ]
+
+        # Keep only columns that exist
+        output_cols = [c for c in output_cols if c in combined.columns]
+        result = combined[output_cols].reset_index(drop=True)
+
+        logger.info(
+            f"Availability summary — "
+            f"Available: {result['is_available'].sum()} | "
+            f"Unavailable: {(~result['is_available']).sum()} | "
+            f"Total: {len(result)}"
+        )
+        return result

--- a/src/availability/injury_normalizer.py
+++ b/src/availability/injury_normalizer.py
@@ -1,0 +1,121 @@
+"""
+Injury Status Normalizer
+========================
+Converts the raw status strings found in the official NBA injury report PDF into
+a canonical five-level scale and assigns each player a *play probability* for
+their next scheduled game.
+
+Canonical statuses (from most to least certain to sit out):
+    Out          → 0.02   (near-certain DNP)
+    Doubtful     → 0.15   (very unlikely to play)
+    Questionable → 0.50   (coin-flip)
+    Probable     → 0.85   (very likely to play)
+    Available    → 0.97   (essentially certain to play)
+
+Any raw string that cannot be mapped defaults to "Questionable" / 0.50.
+
+Public API
+----------
+    normalize_status(raw_status: str) -> str
+    play_probability(canonical_status: str) -> float
+    normalize_report(df: pd.DataFrame) -> pd.DataFrame
+"""
+
+import re
+import pandas as pd
+from common.constants import (
+    AVAILABILITY_STATUS_MAP,
+    AVAILABILITY_PLAY_PROBABILITY,
+)
+
+
+# ---------------------------------------------------------------------------
+# Low-level helpers
+# ---------------------------------------------------------------------------
+
+
+def normalize_status(raw_status: str) -> str:
+    """
+    Map a raw PDF status string to one of the five canonical statuses.
+
+    The mapping is fuzzy: it first tries an exact lookup (case-insensitive),
+    then falls back to substring / regex matching defined in
+    ``AVAILABILITY_STATUS_MAP``.
+
+    Args:
+        raw_status: Raw string as parsed from the PDF (e.g. "OUT", "GTD",
+                    "QUESTIONABLE", "DNP – rest", …).
+
+    Returns:
+        One of: "Out", "Doubtful", "Questionable", "Probable", "Available".
+    """
+    if not isinstance(raw_status, str) or not raw_status.strip():
+        return "Questionable"
+
+    cleaned = raw_status.strip().upper()
+
+    # Direct key lookup first (fastest path)
+    if cleaned in AVAILABILITY_STATUS_MAP:
+        return AVAILABILITY_STATUS_MAP[cleaned]
+
+    # Substring / pattern matching
+    for pattern, canonical in AVAILABILITY_STATUS_MAP.items():
+        if re.search(pattern, cleaned):
+            return canonical
+
+    return "Questionable"
+
+
+def play_probability(canonical_status: str) -> float:
+    """
+    Return the prior probability that a player with *canonical_status* will
+    play in their next game.
+
+    Args:
+        canonical_status: One of the five canonical status strings.
+
+    Returns:
+        Float in [0, 1].
+    """
+    return AVAILABILITY_PLAY_PROBABILITY.get(canonical_status, 0.50)
+
+
+# ---------------------------------------------------------------------------
+# DataFrame-level transform
+# ---------------------------------------------------------------------------
+
+
+def normalize_report(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Apply status normalization and play-probability assignment to a raw
+    injury report DataFrame produced by ``InjuryReportCollector``.
+
+    Input columns expected:
+        report_date, matchup, team, player_name, status, reason
+
+    Added / modified columns:
+        status          → overwritten with canonical value
+        raw_status      → original value preserved here
+        play_probability → float [0,1]
+
+    Args:
+        df: Raw injury report DataFrame.
+
+    Returns:
+        Enriched DataFrame with canonical status + play probability columns.
+    """
+    if df.empty:
+        return df.copy()
+
+    out = df.copy()
+
+    # Preserve original string
+    out["raw_status"] = out["status"].astype(str)
+
+    # Canonical status
+    out["status"] = out["raw_status"].apply(normalize_status)
+
+    # Play probability
+    out["play_probability"] = out["status"].apply(play_probability)
+
+    return out

--- a/src/data_collectors/get_injury_report.py
+++ b/src/data_collectors/get_injury_report.py
@@ -1,0 +1,370 @@
+"""
+Injury Report Collector
+
+Fetches the latest NBA official injury/availability PDF report,
+parses it into a structured DataFrame, and persists it to storage.
+
+Output schema:
+    report_date   : str  (MM/DD/YYYY)
+    matchup       : str  (e.g. "MIL@BOS")
+    team          : str  (full CamelCase team name, e.g. "MilwaukeeBucks")
+    player_name   : str  (Lastname,Firstname)
+    status        : str  (Out | Doubtful | Questionable | Probable | Available)
+    reason        : str  (free-text injury description)
+"""
+
+import re
+import datetime
+import logging
+import requests
+import pdfplumber
+import pandas as pd
+from io import BytesIO
+
+from common.singleton_meta import SingletonMeta
+from common.io_utils import InjuryReportFileName, save_database
+
+logger = logging.getLogger(__name__)
+
+# Hours tried in order from earliest to latest.  The loop stops as soon as a
+# URL stops returning HTTP 200, so we always pick the freshest published file.
+_HOURS_TO_TRY = [
+    "02_00AM",
+    "04_00AM",
+    "06_00AM",
+    "08_00AM",
+    "10_00AM",
+    "11_00AM",
+    "12_00PM",
+    "01_00PM",
+    "02_00PM",
+    "03_00PM",
+    "04_00PM",
+    "05_00PM",
+    "06_00PM",
+    "08_00PM",
+]
+
+_PDF_BASE_URL = (
+    "https://ak-static.cms.nba.com/referee/injury/Injury-Report_{date}_{hour}.pdf"
+)
+
+
+class InjuryReportCollector(metaclass=SingletonMeta):
+    """
+    Fetches and parses the official NBA injury report PDF for a given date,
+    then persists the raw structured records to storage.
+
+    Args:
+        report_date (str | None): ISO date string "YYYY-MM-DD".
+            Defaults to today (UTC).
+        save_mode (str): "local" or "bq".
+    """
+
+    def __init__(
+        self,
+        save_mode: str = "local",
+        report_date: str | None = None,
+    ) -> None:
+        self.save_mode = save_mode
+        if report_date:
+            self.report_date = datetime.datetime.strptime(
+                report_date, "%Y-%m-%d"
+            ).date()
+        else:
+            self.report_date = datetime.datetime.utcnow().date()
+
+    # ------------------------------------------------------------------
+    # PDF resolution
+    # ------------------------------------------------------------------
+
+    def _resolve_pdf_url(self) -> str:
+        """
+        Try each candidate hour and return the last URL that returned HTTP 200.
+        The NBA typically publishes one report per day but updates it during the day.
+        """
+        date_str = self.report_date.strftime("%Y-%m-%d")
+        last_valid: str | None = None
+
+        for hour in _HOURS_TO_TRY:
+            url = _PDF_BASE_URL.format(date=date_str, hour=hour)
+            try:
+                resp = requests.head(url, timeout=10)
+                if resp.status_code == 200:
+                    last_valid = url
+                else:
+                    break  # stop at the first hour that has no file yet
+            except requests.RequestException as exc:
+                logger.debug(f"HEAD request failed for {url}: {exc}")
+                break
+
+        if last_valid is None:
+            raise FileNotFoundError(
+                f"No injury report PDF found for {date_str}. "
+                "The report may not yet have been published."
+            )
+        return last_valid
+
+    # ------------------------------------------------------------------
+    # PDF parsing
+    # ------------------------------------------------------------------
+
+    def _parse_pdf(self, pdf_url: str) -> pd.DataFrame:
+        """Download and parse the PDF into a list of injury records.
+
+        Real NBA injury-report PDFs have an unusual flat-text structure:
+        - Date, time, matchup, team name, player name, status, and reason can
+          all appear on a single line.
+        - Team names are CamelCase with no spaces (e.g. "MilwaukeeBucks").
+        - Multi-line injury reasons are very common.
+        - Page headers ("Injury Report: …") and footers ("Page1of11") must be
+          stripped before any other processing.
+        - Teams that haven't filed appear as "TeamName NOTYETSUBMITTED".
+        """
+        response = requests.get(pdf_url, timeout=30)
+        response.raise_for_status()
+        pdf_content = BytesIO(response.content)
+
+        today_str = self.report_date.strftime("%m/%d/%Y")
+
+        # ------------------------------------------------------------------
+        # Compiled patterns
+        # ------------------------------------------------------------------
+
+        # Full date+time+matchup line, e.g.:
+        #   "03/30/2025 03:30(ET) LAC@CLE LAClippers BaldwinJr.,Patrick Out ..."
+        date_matchup_pat = re.compile(
+            r"^(\d{2}/\d{2}/\d{4})\s+\d{1,2}:\d{2}\(ET\)\s+([A-Z]{2,4}@[A-Z]{2,4})"
+        )
+
+        # Time-only+matchup line (same day, new game), e.g.:
+        #   "06:00(ET) POR@NYK PortlandTrailBlazers Ayton,Deandre Out ..."
+        time_matchup_pat = re.compile(r"^\d{1,2}:\d{2}\(ET\)\s+([A-Z]{2,4}@[A-Z]{2,4})")
+
+        # Bare matchup line — no date or time prefix, appears after page breaks
+        # when pdfplumber merges the time token into the previous page's last line.
+        # e.g. "PHX@CHA PhoenixSuns Coffey,Amir Out ..."
+        #      "MIN@PHI MinnesotaTimberwolves NOTYETSUBMITTED"
+        bare_matchup_pat = re.compile(r"^([A-Z]{2,4}@[A-Z]{2,4})(?:\s|$)")
+
+        # CamelCase team name token: alphabetic, length > 5, mixed case.
+        # Examples: "LAClippers", "ClevelandCavaliers", "PortlandTrailBlazers",
+        #           "OKCThunder", "MilwaukeeBucks"
+        # NOTE: we also require the NEXT token to be a player or NOTYETSUBMITTED
+        # so that single-word reason continuations ("Management", "Tendinopathy")
+        # are not misidentified as team names.
+
+        # Player token: "Lastname,Firstname" or "LastnameJr.,Firstname" etc.
+        player_pat = re.compile(r"^[^,\s]+,[^\s]+$")
+
+        # Lines to strip entirely
+        skip_pat = re.compile(r"^(Injury Report:|GameDate\s+GameTime|Page\d+of\d+$)")
+
+        # ------------------------------------------------------------------
+        # Helpers
+        # ------------------------------------------------------------------
+
+        def _is_player(token: str) -> bool:
+            return bool(player_pat.match(token))
+
+        def _looks_like_team_token(token: str) -> bool:
+            """True for mixed-case team name tokens (alphanumeric, length > 5, mixed case).
+            Handles teams with digits in the name e.g. 'Philadelphia76ers'.
+            """
+            return (
+                bool(re.match(r"^[A-Za-z0-9]+$", token))
+                and len(token) > 5
+                and any(c.isupper() for c in token)
+                and any(c.islower() for c in token)
+            )
+
+        def _is_team_line_start(parts: list[str]) -> bool:
+            """
+            A line starts with a team token if:
+              - parts[0] looks like a team token, AND
+              - parts[1] is a player token OR 'NOTYETSUBMITTED'
+            This lookahead prevents single-word reasons ('Management') from
+            being mistaken for team names.
+            """
+            if len(parts) < 2:
+                return False
+            if not _looks_like_team_token(parts[0]):
+                return False
+            return _is_player(parts[1]) or parts[1] == "NOTYETSUBMITTED"
+
+        def _consume_matchup_line(parts: list[str], matchup: str) -> None:
+            """
+            After extracting the matchup token from *parts*, pull out the
+            optional CamelCase team and optional player+status+reason that
+            may follow on the same line.
+            """
+            nonlocal current_matchup, current_team, current_record
+            current_matchup = matchup
+
+            # Find position of the matchup token and advance past it
+            # (parts may still contain the time/date tokens at index 0,1 …)
+            for i, p in enumerate(parts):
+                if p == matchup:
+                    remaining = parts[i + 1 :]
+                    break
+            else:
+                remaining = []
+
+            # Optional team name immediately after matchup token
+            if remaining and _looks_like_team_token(remaining[0]):
+                current_team = remaining[0]
+                remaining = remaining[1:]
+
+            # Optional "NOTYETSUBMITTED" — no player data
+            if remaining and remaining[0] == "NOTYETSUBMITTED":
+                return
+
+            # Optional player record on the same line
+            if remaining and _is_player(remaining[0]):
+                current_record = _make_record(remaining)
+                if current_record:
+                    records.append(current_record)
+
+        def _make_record(parts: list[str]) -> dict | None:
+            if len(parts) < 2:
+                return None
+            return {
+                "report_date": date_part,
+                "matchup": current_matchup or "",
+                "team": current_team or "",
+                "player_name": parts[0],
+                "status": parts[1],
+                "reason": " ".join(parts[2:]) if len(parts) > 2 else "",
+            }
+
+        # ------------------------------------------------------------------
+        # Main parse loop
+        # ------------------------------------------------------------------
+
+        records: list[dict] = []
+        current_matchup: str | None = None
+        current_team: str | None = None
+        current_record: dict | None = None
+        date_part: str = today_str
+
+        with pdfplumber.open(pdf_content) as pdf:
+            for page in pdf.pages:
+                raw_text = page.extract_text()
+                if not raw_text:
+                    continue
+
+                for line in raw_text.split("\n"):
+                    line = line.strip()
+                    if not line:
+                        continue
+
+                    # 1. Strip header / footer lines unconditionally
+                    if skip_pat.match(line):
+                        continue
+
+                    parts = line.split()
+
+                    # 2. Date + matchup line
+                    #    "MM/DD/YYYY HH:MM(ET) LAC@CLE ..."
+                    m = date_matchup_pat.match(line)
+                    if m:
+                        date_part = m.group(1)
+                        matchup_token = m.group(2)
+                        # Skip records for dates other than today
+                        if date_part != today_str:
+                            # Still parse — multi-day reports include next-day
+                            # games; we keep them but tag with their own date.
+                            pass
+                        _consume_matchup_line(parts, matchup_token)
+                        continue
+
+                    # 3. Time-only + matchup line (same date, new game)
+                    #    "06:00(ET) POR@NYK PortlandTrailBlazers ..."
+                    m = time_matchup_pat.match(line)
+                    if m:
+                        matchup_token = m.group(1)
+                        _consume_matchup_line(parts, matchup_token)
+                        continue
+
+                    # 3b. Bare matchup line — no date/time prefix (page-break artifact)
+                    #     "PHX@CHA PhoenixSuns Coffey,Amir Out ..."
+                    #     "MIN@PHI MinnesotaTimberwolves NOTYETSUBMITTED"
+                    m = bare_matchup_pat.match(line)
+                    if m:
+                        matchup_token = m.group(1)
+                        _consume_matchup_line(parts, matchup_token)
+                        continue
+
+                    # We need an active matchup context from here on
+                    if current_matchup is None:
+                        continue
+
+                    # 4. Team name line (possibly followed by player or NOTYETSUBMITTED)
+                    #    "ClevelandCavaliers Bates,Emoni Out GLeague-Two-Way"
+                    #    "CharlotteHornets NOTYETSUBMITTED"
+                    if _is_team_line_start(parts):
+                        current_team = parts[0]
+                        remaining = parts[1:]
+
+                        if not remaining or remaining[0] == "NOTYETSUBMITTED":
+                            current_record = None
+                            continue
+
+                        if _is_player(remaining[0]):
+                            current_record = _make_record(remaining)
+                            if current_record:
+                                records.append(current_record)
+                        # else: unexpected token after team name — treat as
+                        # continuation of previous reason (should not happen)
+                        continue
+
+                    # 5. Player line: "Lastname,Firstname Status [Reason...]"
+                    if _is_player(parts[0]):
+                        current_record = _make_record(parts)
+                        if current_record:
+                            records.append(current_record)
+                        continue
+
+                    # 6. Continuation: append to most-recent player's reason
+                    if records:
+                        records[-1]["reason"] = (
+                            records[-1]["reason"] + " " + line
+                        ).strip()
+                        # Keep current_record in sync
+                        if current_record is not None:
+                            current_record["reason"] = records[-1]["reason"]
+
+        return (
+            pd.DataFrame(records)
+            if records
+            else pd.DataFrame(
+                columns=[
+                    "report_date",
+                    "matchup",
+                    "team",
+                    "player_name",
+                    "status",
+                    "reason",
+                ]
+            )
+        )
+
+    def run(self) -> pd.DataFrame:
+        """Fetch → parse → persist. Returns the raw injury report DataFrame."""
+        logger.info(f"Fetching injury report for {self.report_date} …")
+        pdf_url = self._resolve_pdf_url()
+        logger.info(f"Latest PDF URL: {pdf_url}")
+
+        df = self._parse_pdf(pdf_url)
+        if df.empty:
+            logger.warning("No injury records parsed — nothing to save.")
+            return df
+
+        save_database(
+            df,
+            InjuryReportFileName,
+            mode=self.save_mode,
+            write_disposition="WRITE_TRUNCATE",
+        )
+        logger.info(f"Injury report saved ({len(df)} rows) via mode={self.save_mode}")
+        return df

--- a/src/data_collectors/get_nba_advanced_boxscore.py
+++ b/src/data_collectors/get_nba_advanced_boxscore.py
@@ -17,21 +17,23 @@ class AdvancedBoxscoreGames(metaclass=SingletonMeta):
     A class to fetch and NBA advanced boxscore data for all games in a specific season.
     """
 
-    def __init__(self, current_season: str, save_mode: str, 
-                 proxy_user: str = None, proxy_pass: str = None) -> None:
+    def __init__(self, current_season: str, 
+                 save_mode: str, 
+                 proxy_user: str | None = None, 
+                 proxy_pass: str | None = None) -> None:
         """
         Initialize the AdvancedBoxscoreGames class with the current season and season type.
             Args:
                 current_season (str): The current season in the format "YYYY-YY".
                 save_mode (str): The mode to save data, either 'local' or 'bq' (google bigquery). 
-                proxy_user (str, optional): Proxy username if needed. Defaults to None.
-                proxy_user (str, optional): Proxy password if needed. Defaults to None.
+                proxy_user (str | None, optional): Proxy username if needed. Defaults to None.
+                proxy_pass (str | None, optional): Proxy password if needed. Defaults to None.
         """
         print(f"Initializing AdvancedBoxscoreGames with season: {current_season}")
         self.current_season: str = current_season
         self.current_season_year: int = int(current_season.split("-")[0])
         self.SAVE_MODE: str = save_mode
-        self.proxy: str | None = build_proxy_url(proxy_user, proxy_pass)
+        self.proxy: str | None = build_proxy_url(proxy_user, proxy_pass) if proxy_user and proxy_pass else None
         print(f"[PROXY] advanced_boxscore → {'enabled' if self.proxy else 'disabled (no creds)'}")
 
     def get_schedule(self) -> pd.DataFrame:

--- a/src/data_collectors/get_nba_boxscore_basic.py
+++ b/src/data_collectors/get_nba_boxscore_basic.py
@@ -15,21 +15,23 @@ class BoxscoreGames(metaclass=SingletonMeta):
     """
     A class to fetch and update NBA boxscore data for ended games.
     """
-    def __init__(self, current_season: str, save_mode: str,
-                 proxy_user: str = None, proxy_pass: str = None) -> None:
+    def __init__(self, current_season: str, 
+                 save_mode: str,
+                 proxy_user: str | None = None, 
+                 proxy_pass: str | None = None) -> None:
         """
         Args:
             current_season (str): format "YYYY-YY"
             save_mode (str): 'local' or 'bq'
-            proxy_user (str, optional): Proxy username if needed. Defaults to None.
-            proxy_user (str, optional): Proxy password if needed. Defaults to None.
+            proxy_user (str | None, optional): Proxy username if needed. Defaults to None.
+            proxy_pass (str | None, optional): Proxy password if needed. Defaults to None.
         """
 
         print(f"Initializing BoxscoreGames with season: {current_season}")
         self.current_season: str = current_season
         self.current_season_year: int = int(current_season.split("-")[0])
         self.SAVE_MODE: str = save_mode
-        self.proxy: str | None = build_proxy_url(proxy_user, proxy_pass)
+        self.proxy: str | None = build_proxy_url(proxy_user, proxy_pass) if proxy_user and proxy_pass else None
         print(f"[PROXY] boxscore_basic → {'enabled' if self.proxy else 'disabled (no creds)'}")
 
     def get_schedule(self) -> pd.DataFrame:

--- a/src/data_collectors/get_nba_players.py
+++ b/src/data_collectors/get_nba_players.py
@@ -8,7 +8,6 @@ from common.constants import nba_api_timeout
 from common.utils import build_proxy_url, call_nba_api_with_retry
 
 
-
 class NbaPlayersData(metaclass=SingletonMeta):
     """
     Simple process:
@@ -18,21 +17,30 @@ class NbaPlayersData(metaclass=SingletonMeta):
     - Save with save_database like your other processes
     """
 
-    def __init__(self, current_season: str, save_mode: str,
-                    proxy_user: str = None, proxy_pass: str = None) -> None:
+    def __init__(
+        self,
+        current_season: str,
+        save_mode: str,
+        proxy_user: str | None = None,
+        proxy_pass: str | None = None,
+    ) -> None:
         """
         Initialize the NBA players data for a given season
             Args:
-                current_season (str) : The season to fetch players for, e.g., "2024-25" 
+                current_season (str) : The season to fetch players for, e.g., "2024-25"
                 save_mode (str): Where to save the output ('bq' or 'local')
                 proxy_user (str, optional): Proxy username if needed. Defaults to None.
                 proxy_user (str, optional): Proxy password if needed. Defaults to None.
         """
         self.current_season: str = current_season  # e.g., "2024-25"
         self.SAVE_MODE: str = save_mode
-        self.proxy: str | None = build_proxy_url(proxy_user, proxy_pass)
+        self.proxy: str | None = (
+            build_proxy_url(proxy_user, proxy_pass)
+            if proxy_user and proxy_pass
+            else None
+        )
         print(f"[PROXY] players → {'enabled' if self.proxy else 'disabled (no creds)'}")
-  
+
     def get_nba_players_index(self) -> pd.DataFrame:
         """
         Fetch NBA players data from the NBA stats API and clean it.
@@ -47,31 +55,33 @@ class NbaPlayersData(metaclass=SingletonMeta):
             ).get_data_frames()[0]
         )
 
-        # Select relevant columns 
+        # Select relevant columns
         playerindex_df = playerindex_df[
-            ["PERSON_ID",
-             "PLAYER_LAST_NAME",
-             "PLAYER_FIRST_NAME",
-             "PLAYER_SLUG",
-             "TEAM_ID",
-             "TEAM_ABBREVIATION",
-             "JERSEY_NUMBER",
-             "POSITION",
-             "HEIGHT",
-             "WEIGHT",
-             "COLLEGE",
-             "COUNTRY",
-             "DRAFT_YEAR",
-             "DRAFT_ROUND",
-             "DRAFT_NUMBER",
-             "ROSTER_STATUS",
-             "FROM_YEAR",
-             "TO_YEAR"
-            ]]
-        
-        # Lower case column names 
+            [
+                "PERSON_ID",
+                "PLAYER_LAST_NAME",
+                "PLAYER_FIRST_NAME",
+                "PLAYER_SLUG",
+                "TEAM_ID",
+                "TEAM_ABBREVIATION",
+                "JERSEY_NUMBER",
+                "POSITION",
+                "HEIGHT",
+                "WEIGHT",
+                "COLLEGE",
+                "COUNTRY",
+                "DRAFT_YEAR",
+                "DRAFT_ROUND",
+                "DRAFT_NUMBER",
+                "ROSTER_STATUS",
+                "FROM_YEAR",
+                "TO_YEAR",
+            ]
+        ]
+
+        # Lower case column names
         playerindex_df.columns = [col.lower() for col in playerindex_df.columns]
-                
+
         return playerindex_df
 
     def run(self) -> None:
@@ -80,7 +90,9 @@ class NbaPlayersData(metaclass=SingletonMeta):
             df = self.get_nba_players_index()
             if df is not None and not df.empty:
                 save_database(df, PlayersFileName, mode=self.SAVE_MODE)
-                print(f"✅ Players data saved with mode: {self.SAVE_MODE} (rows={len(df)})")
+                print(
+                    f"✅ Players data saved with mode: {self.SAVE_MODE} (rows={len(df)})"
+                )
             else:
                 print("⚠️ No players data fetched. Process skipped.")
         except Exception as e:

--- a/src/data_collectors/get_nba_schedule.py
+++ b/src/data_collectors/get_nba_schedule.py
@@ -13,19 +13,21 @@ class ScheduleData(metaclass=SingletonMeta):
     A class to fetch and update NBA schedule data. 
     """
 
-    def __init__(self, current_season: str, save_mode: str,
-                proxy_user:str = None, proxy_pass: str = None) -> None: 
+    def __init__(self, 
+                 current_season: str, save_mode: str,
+                proxy_user: str | None = None, 
+                proxy_pass: str | None = None) -> None: 
         """
         Initialize the NBA schedule data for a given season
             Args:
             current_season (str) : The season to fetch players for, e.g., "2024-25" 
             save_mode (str): Where to save the output ('bq' or 'local')
-            proxy_user (str, optional): Proxy username if needed. Defaults to None.
-            proxy_user (str, optional): Proxy password if needed. Defaults to None.
+            proxy_user (str | None, optional): Proxy username if needed. Defaults to None.
+            proxy_pass (str | None, optional): Proxy password if needed. Defaults to None.
         """
         self.current_season: str = current_season
         self.SAVE_MODE: str = save_mode
-        self.proxy: str | None = build_proxy_url(proxy_user, proxy_pass)
+        self.proxy: str | None = build_proxy_url(proxy_user, proxy_pass) if proxy_user and proxy_pass else None
         print(f"[PROXY] schedule → {'enabled' if self.proxy else 'disabled (no creds)'}")
 
     

--- a/src/predictors/unified_predictor.py
+++ b/src/predictors/unified_predictor.py
@@ -391,12 +391,9 @@ class UnifiedPredictor(metaclass=SingletonMeta):
         )
         logger.info("Predictions persisted successfully!")
 
-    def run(self) -> pd.DataFrame:
+    def run(self) ->None:
         """
         Execute complete prediction pipeline: read → transform → predict → persist.
-
-        Returns:
-            DataFrame with predictions
         """
         try:
             logger.info(f"Starting prediction pipeline for {self.target}...")
@@ -423,7 +420,6 @@ class UnifiedPredictor(metaclass=SingletonMeta):
             )
 
             logger.info("Prediction pipeline completed successfully!")
-            return predictions_df
 
         except Exception as e:
             logger.error(f"Prediction pipeline failed: {str(e)}")

--- a/src/predictors/unified_predictor.py
+++ b/src/predictors/unified_predictor.py
@@ -12,16 +12,33 @@ from typing import Dict, Any
 
 from common.singleton_meta import SingletonMeta
 from common.io_utils import (
-    BoxscoreFileName, AdvancedBoxscoreFileName, 
-    PlayersFileName, PredictionsFileName, ScheduleFileName,
-    load_data, save_predictions
+    BoxscoreFileName,
+    AdvancedBoxscoreFileName,
+    PlayersFileName,
+    PredictionsFileName,
+    ScheduleFileName,
+    AvailabilityFileName,
+    load_data,
+    save_predictions,
 )
 from common.model_utils import load_model_artifact
-from common.constants import TARGET_CONFIGS
+from common.constants import (
+    TARGET_CONFIGS,
+    PREDICTION_EXCLUDE_THRESHOLD,
+    CONFIDENCE_MAX_VOLATILITY,
+    CONFIDENCE_SAMPLE_SIZE_CAP,
+)
 from common.feature_engineering import (
-    merge_data, preprocess_data, create_historical_features, 
-    normalize_features, compute_rolling_stats, encode_categorical_features,
-    get_feature_cols, get_volatility, get_final_df, get_rest_days
+    merge_data,
+    preprocess_data,
+    create_historical_features,
+    normalize_features,
+    compute_rolling_stats,
+    encode_categorical_features,
+    get_feature_cols,
+    get_volatility,
+    get_final_df,
+    get_rest_days,
 )
 
 logger = logging.getLogger(__name__)
@@ -30,16 +47,10 @@ logger = logging.getLogger(__name__)
 class UnifiedPredictor(metaclass=SingletonMeta):
     """Unified predictor for both points and fantasy points predictions."""
 
-    def __init__(
-        self,
-        target: str,
-        save_mode: str,
-        date: str,
-        model_path: str
-    ) -> None:
+    def __init__(self, target: str, save_mode: str, date: str, model_path: str) -> None:
         """
         Initialize the unified predictor.
-        
+
         Args:
             target: Target variable ('points' or 'fantasy_points')
             save_mode: Save mode ('local' or 'bq')
@@ -49,38 +60,41 @@ class UnifiedPredictor(metaclass=SingletonMeta):
         # Validate target
         if target not in TARGET_CONFIGS:
             available_targets = list(TARGET_CONFIGS.keys())
-            raise ValueError(f"Invalid target: {target}. Available targets: {available_targets}")
-        
+            raise ValueError(
+                f"Invalid target: {target}. Available targets: {available_targets}"
+            )
+
         self.target = target
         self.save_mode = save_mode
         self.date = datetime.datetime.strptime(date, "%Y-%m-%d").date()
         self.model_path = model_path
-        
+
         # Load target-specific configuration
         config = TARGET_CONFIGS[target]
-        self.key_stats = config['key_stats']
-        self.categorical_cols = config['categorical_cols']
-        self.target_variable = config['target_variable']
-        self.rolling_windows = config['rolling_windows']
-        self.measure_prediction = config['measure_prediction']
-        self.measure_volatility = config['measure_volatility']
-        
+        self.key_stats = config["key_stats"]
+        self.categorical_cols = config["categorical_cols"]
+        self.target_variable = config["target_variable"]
+        self.rolling_windows = config["rolling_windows"]
+        self.measure_prediction = config["measure_prediction"]
+        self.measure_volatility = config["measure_volatility"]
+
         # Handle target computation function (lazy import to avoid circular dependencies)
-        if config['target_computer_fn']:
-            if config['target_computer_fn'] == 'compute_fantasy_points':
+        if config["target_computer_fn"]:
+            if config["target_computer_fn"] == "compute_fantasy_points":
                 from src.targets.fantasy_points import compute_fantasy_points
+
                 self.target_computer_fn = compute_fantasy_points
             else:
                 self.target_computer_fn = None
         else:
             self.target_computer_fn = None
-        
+
         logger.info(f"Initialized UnifiedPredictor for target: {target}")
 
     def read_data(self) -> Dict[str, pd.DataFrame]:
         """
         Read necessary data from storage.
-        
+
         Returns:
             Dictionary containing loaded dataframes
         """
@@ -89,29 +103,35 @@ class UnifiedPredictor(metaclass=SingletonMeta):
         adv = load_data(AdvancedBoxscoreFileName, mode=self.save_mode)
         players = load_data(PlayersFileName, mode=self.save_mode)
         schedule = load_data(ScheduleFileName, mode=self.save_mode)
+        availability = load_data(AvailabilityFileName, mode=self.save_mode)
 
         return {
             BoxscoreFileName: box,
             AdvancedBoxscoreFileName: adv,
             PlayersFileName: players,
-            ScheduleFileName: schedule
+            ScheduleFileName: schedule,
+            AvailabilityFileName: availability,
         }
 
     def get_future_games_players(self, data_map: dict) -> pd.DataFrame:
         """
         Get future games with player information for the specified date.
-        
+        Players marked as unavailable in the availability table are excluded.
+
         Args:
             data_map: Dictionary containing loaded dataframes
-            
+
         Returns:
             DataFrame with future games and player info
         """
         all_schedule_df = data_map[ScheduleFileName]
         players_df = data_map[PlayersFileName]
-        
+        availability_df = data_map.get(AvailabilityFileName, pd.DataFrame())
+
         # Filter schedule for the specific date
-        all_schedule_df["gameDate"] = pd.to_datetime(all_schedule_df["gameDate"]).dt.date
+        all_schedule_df["gameDate"] = pd.to_datetime(
+            all_schedule_df["gameDate"]
+        ).dt.date
         specific_games_df = all_schedule_df[all_schedule_df["gameDate"] == self.date]
 
         # Handle case with no games
@@ -119,60 +139,118 @@ class UnifiedPredictor(metaclass=SingletonMeta):
             logger.warning(f"No games found for the selected date: {self.date}")
             raise ValueError(f"No games scheduled for {self.date}")
 
-        # Prepare players data
-        players_unique = players_df[['person_id', 'player_slug', 'team_id', 'position']].drop_duplicates()
+        # Build the set of excluded person_ids: only players whose play_probability
+        # is below PREDICTION_EXCLUDE_THRESHOLD (i.e. "Out" only by default).
+        excluded_ids: set = set()
+        if not availability_df.empty and "play_probability" in availability_df.columns:
+            excluded_ids = set(
+                availability_df.loc[
+                    availability_df["play_probability"] < PREDICTION_EXCLUDE_THRESHOLD,
+                    "person_id",
+                ]
+                .dropna()
+                .astype(int)
+            )
+            n_out = len(excluded_ids)
+            logger.info(
+                f"Availability filter: {n_out} player(s) with play_probability < "
+                f"{PREDICTION_EXCLUDE_THRESHOLD} (Out) excluded from predictions."
+            )
+
+        # Prepare players data — exclude only Out players
+        players_unique = players_df[
+            ["person_id", "player_slug", "team_id", "position"]
+        ].drop_duplicates()
+        if excluded_ids:
+            before = len(players_unique)
+            players_unique = players_unique[
+                ~players_unique["person_id"].isin(excluded_ids)
+            ]
+            logger.info(
+                f"Filtered {before - len(players_unique)} Out player(s) from roster."
+            )
 
         # Cross join players with specific games
-        specific_games_df = pd.concat([
-            specific_games_df.merge(players_unique, left_on='homeTeam_teamId', right_on='team_id'),
-            specific_games_df.merge(players_unique, left_on='awayTeam_teamId', right_on='team_id')
-        ], ignore_index=True)
-        
+        specific_games_df = pd.concat(
+            [
+                specific_games_df.merge(
+                    players_unique, left_on="homeTeam_teamId", right_on="team_id"
+                ),
+                specific_games_df.merge(
+                    players_unique, left_on="awayTeam_teamId", right_on="team_id"
+                ),
+            ],
+            ignore_index=True,
+        )
+
         # Add opponent team id column
-        specific_games_df['opponent'] = np.where(
-            specific_games_df['team_id'] == specific_games_df['homeTeam_teamId'],
-            specific_games_df['awayTeam_teamId'],
-            specific_games_df['homeTeam_teamId']
+        specific_games_df["opponent"] = np.where(
+            specific_games_df["team_id"] == specific_games_df["homeTeam_teamId"],
+            specific_games_df["awayTeam_teamId"],
+            specific_games_df["homeTeam_teamId"],
         )
 
         # Add position group column (needed for fantasy)
-        specific_games_df['position_group'] = specific_games_df['position'].map(
-            lambda x: 'G' if x in ('G', 'G-F') else 'F' if x in ('F', 'F-G', 'F-C') else 'C' if x in ('C', 'C-F') else x
+        specific_games_df["position_group"] = specific_games_df["position"].map(
+            lambda x: "G"
+            if x in ("G", "G-F")
+            else "F"
+            if x in ("F", "F-G", "F-C")
+            else "C"
+            if x in ("C", "C-F")
+            else x
         )
-        
-        # Additional columns needed for feature engineering
-        specific_games_df['is_home'] = specific_games_df['team_id'] == specific_games_df['homeTeam_teamId']
-        specific_games_df['season'] = specific_games_df['gameId'].astype(str).str[1:3].astype(int) + 2000
-        specific_games_df['game_date'] = pd.to_datetime(specific_games_df['gameDate'])
 
-        logger.info(f"Found {len(specific_games_df)} player-game combinations for {self.date}")
+        # Additional columns needed for feature engineering
+        specific_games_df["is_home"] = (
+            specific_games_df["team_id"] == specific_games_df["homeTeam_teamId"]
+        )
+        specific_games_df["season"] = (
+            specific_games_df["gameId"].astype(str).str[1:3].astype(int) + 2000
+        )
+        specific_games_df["game_date"] = pd.to_datetime(specific_games_df["gameDate"])
+
+        logger.info(
+            f"Found {len(specific_games_df)} player-game combinations for {self.date}"
+        )
         return specific_games_df
 
-    def transform_data(self, data_map: dict, model: Any) -> pd.DataFrame:
+    def transform_data(
+        self, data_map: dict, model: Any
+    ) -> tuple[pd.DataFrame, pd.DataFrame]:
         """
         Transform data for predictions.
-        
+
         Args:
             data_map: Dictionary containing loaded dataframes
             model: Trained model
-            
+
         Returns:
-            DataFrame with predictions
+            Tuple of (predictions_df, games_played_df) where games_played_df has
+            columns [personId, games_played] counted from historical boxscore.
         """
         logger.info("Transforming data for predictions...")
-        
+
         # Load historical data
         box = data_map[BoxscoreFileName]
         adv = data_map[AdvancedBoxscoreFileName]
 
         # Filter historical data to be strictly before prediction date
-        box = box[pd.to_datetime(box['game_date']).dt.date < self.date]
-        adv = adv[pd.to_datetime(adv['game_date']).dt.date < self.date]
-        
+        box = box[pd.to_datetime(box["game_date"]).dt.date < self.date]
+        adv = adv[pd.to_datetime(adv["game_date"]).dt.date < self.date]
+
+        # Count distinct games played per player (before any filtering)
+        games_played_df = (
+            box.groupby("personId")["gameId"]
+            .nunique()
+            .reset_index()
+            .rename(columns={"gameId": "games_played"})
+        )
+
         # Merge & Preprocess Historical
         df_hist = merge_data(box, adv, data_map[PlayersFileName])
         df_hist = preprocess_data(df_hist)
-        
+
         # Compute target if custom function provided (fantasy points)
         if self.target_computer_fn:
             logger.info(f"Computing {self.target_variable}...")
@@ -180,42 +258,39 @@ class UnifiedPredictor(metaclass=SingletonMeta):
 
         # Create Historical Features
         df_hist = create_historical_features(df_hist, target_col=self.target_variable)
-        
+
         # Calculate Rest Days
         rest_days_df = get_rest_days(
-            players_df=data_map[PlayersFileName],
-            boxscore_df=box,
-            date=self.date
+            players_df=data_map[PlayersFileName], boxscore_df=box, date=self.date
         )
 
         # Merge rest days into historical data
-        df_hist = df_hist.merge(rest_days_df, on=['personId'], how='left')
-        
+        df_hist = df_hist.merge(rest_days_df, on=["personId"], how="left")
+
         # Normalize and Compute Rolling Stats
         df_hist = normalize_features(df_hist, self.key_stats)
-        df_hist = compute_rolling_stats(df_hist, self.key_stats, windows=self.rolling_windows)
-        
+        df_hist = compute_rolling_stats(
+            df_hist, self.key_stats, windows=self.rolling_windows
+        )
+
         # Prepare Future Data
         future_games = self.get_future_games_players(data_map)
-        
+
         # Get feature columns
         features_list = get_feature_cols(
-            key_stats=self.key_stats,
-            rolling_periods=self.rolling_windows
+            key_stats=self.key_stats, rolling_periods=self.rolling_windows
         )
 
         # Encode Categoricals
         encoded_df, encoded_feature_names = encode_categorical_features(
-            df=df_hist,
-            categorical_cols=self.categorical_cols
+            df=df_hist, categorical_cols=self.categorical_cols
         )
-        
+
         # Get volatility
         volatility_df = get_volatility(
-            df_historical=df_hist,
-            target_variable=self.target_variable
+            df_historical=df_hist, target_variable=self.target_variable
         )
-        
+
         # Get final predictions DataFrame
         final_df = get_final_df(
             encoded_df=encoded_df,
@@ -225,56 +300,131 @@ class UnifiedPredictor(metaclass=SingletonMeta):
             feature_names=features_list,
             encoded_feature_names=encoded_feature_names,
             measure_prediction=self.measure_prediction,
-            measure_volatility=self.measure_volatility
+            measure_volatility=self.measure_volatility,
         )
 
-        return final_df
+        return final_df, games_played_df
 
-    def persist(self, predictions_df: pd.DataFrame) -> None:
+    def persist(
+        self,
+        predictions_df: pd.DataFrame,
+        availability_df: pd.DataFrame,
+        games_played_df: pd.DataFrame,
+    ) -> None:
         """
-        Save predictions to storage.
-        
+        Compute confidence scores, clip negative predictions, then save.
+
+        Confidence formula (all factors 0–1, product gives final score):
+          stability     = 1 - min(volatility / CONFIDENCE_MAX_VOLATILITY, 1.0)
+          sample_conf   = min(games_played / CONFIDENCE_SAMPLE_SIZE_CAP, 1.0)
+          confidence    = play_probability × stability × sample_conf
+
+        Confidence is set only on prediction rows (measure_prediction); volatility
+        rows carry NaN so consumers can ignore them.
+
         Args:
-            predictions_df: DataFrame with predictions
+            predictions_df:  Wide DataFrame produced by transform_data() containing
+                             both prediction and volatility rows.
+            availability_df: Loaded availability table (may be empty).
+            games_played_df: DataFrame with [personId, games_played] from boxscore.
         """
         logger.info(f"Persisting {self.target} predictions...")
+
+        # ── 1. Clip negative predictions ────────────────────────────────────
+        predictions_df["Predictions"] = predictions_df["Predictions"].clip(lower=0)
+
+        # ── 2. Separate prediction rows from volatility rows ────────────────
+        pred_mask = predictions_df["Measure"] == self.measure_prediction
+        pred_rows = predictions_df[pred_mask].copy()
+        vol_rows = predictions_df[~pred_mask].copy()
+
+        # ── 3. Attach volatility to prediction rows (inner join on personId) ─
+        vol_lookup = vol_rows[["personId", "Predictions"]].rename(
+            columns={"Predictions": "_volatility"}
+        )
+        pred_rows = pred_rows.merge(vol_lookup, on="personId", how="left")
+
+        # ── 4. Attach play_probability from availability table ───────────────
+        if not availability_df.empty and "play_probability" in availability_df.columns:
+            avail_lookup = (
+                availability_df[["person_id", "play_probability"]]
+                .drop_duplicates("person_id")
+                .rename(columns={"person_id": "personId"})
+            )
+            pred_rows = pred_rows.merge(avail_lookup, on="personId", how="left")
+        else:
+            pred_rows["play_probability"] = np.nan
+
+        # Missing availability → player is healthy, use default 0.97
+        pred_rows["play_probability"] = pred_rows["play_probability"].fillna(0.97)
+
+        # ── 5. Attach games_played ───────────────────────────────────────────
+        pred_rows = pred_rows.merge(games_played_df, on="personId", how="left")
+        pred_rows["games_played"] = pred_rows["games_played"].fillna(0)
+
+        # ── 6. Compute confidence ────────────────────────────────────────────
+        stability = 1.0 - (
+            pred_rows["_volatility"]
+            .fillna(CONFIDENCE_MAX_VOLATILITY)  # NaN → worst-case stability
+            .clip(upper=CONFIDENCE_MAX_VOLATILITY)
+            .div(CONFIDENCE_MAX_VOLATILITY)
+        )
+        sample_conf = (
+            pred_rows["games_played"]
+            .clip(upper=CONFIDENCE_SAMPLE_SIZE_CAP)
+            .div(CONFIDENCE_SAMPLE_SIZE_CAP)
+        )
+        pred_rows["confidence"] = (
+            pred_rows["play_probability"] * stability * sample_conf
+        ).round(2)
+
+        # ── 7. Drop helper columns, reassemble, save ─────────────────────────
+        pred_rows = pred_rows.drop(
+            columns=["_volatility", "play_probability", "games_played"]
+        )
+        vol_rows["confidence"] = np.nan
+
+        output_df = pd.concat([pred_rows, vol_rows], ignore_index=True)
+
         save_predictions(
-            df=predictions_df,
-            table_name=PredictionsFileName,
-            mode=self.save_mode
+            df=output_df, table_name=PredictionsFileName, mode=self.save_mode
         )
         logger.info("Predictions persisted successfully!")
 
     def run(self) -> pd.DataFrame:
         """
         Execute complete prediction pipeline: read → transform → predict → persist.
-        
+
         Returns:
             DataFrame with predictions
         """
         try:
             logger.info(f"Starting prediction pipeline for {self.target}...")
-            
+
             # 1. Load Model
             logger.info(f"Loading model from: {self.model_path}...")
             model = load_model_artifact(
-                model_path=self.model_path,
-                target=self.target,
-                mode=self.save_mode
+                model_path=self.model_path, target=self.target, mode=self.save_mode
             )
-            
+
             # 2. Read Data
             data_map = self.read_data()
-            
-            # 3. Transform Data & Make Predictions
-            predictions_df = self.transform_data(data_map=data_map, model=model)
 
-            # 4. Persist Results
-            self.persist(predictions_df=predictions_df)
-            
+            # 3. Transform Data & Make Predictions
+            predictions_df, games_played_df = self.transform_data(
+                data_map=data_map, model=model
+            )
+
+            # 4. Persist Results (includes confidence computation)
+            self.persist(
+                predictions_df=predictions_df,
+                availability_df=data_map.get(AvailabilityFileName, pd.DataFrame()),
+                games_played_df=games_played_df,
+            )
+
             logger.info("Prediction pipeline completed successfully!")
             return predictions_df
-            
+
         except Exception as e:
             logger.error(f"Prediction pipeline failed: {str(e)}")
             raise

--- a/tests/test_availability_table.py
+++ b/tests/test_availability_table.py
@@ -1,0 +1,379 @@
+"""
+Unit tests for src/availability/availability_table.py
+
+Tests cover:
+  - _build: schema, available/unavailable row counts, threshold behaviour
+  - _build: full roster appears in output even when not in injury report
+  - _build: injured players override the Available baseline
+  - _build: empty injury report → all players Available
+  - _build: empty players DataFrame → returns empty
+  - run: calls save_database and returns DataFrame (mocked I/O)
+"""
+
+import datetime
+import unittest
+from unittest.mock import patch, MagicMock
+
+import pandas as pd
+
+from common.singleton_meta import SingletonMeta
+from common.constants import (
+    AVAILABILITY_DEFAULT_THRESHOLD,
+    AVAILABILITY_PLAY_PROBABILITY,
+)
+
+
+def _reset_singleton(cls):
+    if cls in SingletonMeta._instances:
+        del SingletonMeta._instances[cls]
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_players_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "person_id": [1, 2, 3, 4],
+            "player_slug": [
+                "giannis-antetokounmpo",
+                "jaylen-brown",
+                "lebron-james",
+                "stephen-curry",
+            ],
+            "team_id": [1610612749, 1610612738, 1610612747, 1610612744],
+            "team_abbreviation": ["MIL", "BOS", "LAL", "GSW"],
+            "player_last_name": ["Antetokounmpo", "Brown", "James", "Curry"],
+            "player_first_name": ["Giannis", "Jaylen", "LeBron", "Stephen"],
+        }
+    )
+
+
+def _make_injury_df(statuses: dict | None = None) -> pd.DataFrame:
+    """
+    Build a raw injury report with a subset of players.
+    statuses: {player_name_pdf: status_string}
+    Default: Giannis=Out, Jaylen=GTD
+    """
+    if statuses is None:
+        statuses = {
+            "Antetokounmpo,Giannis": "Out",
+            "Brown,Jaylen": "GTD",
+        }
+    n = len(statuses)
+    teams_pool = ["MIL", "BOS", "LAL", "GSW", "PHX", "MIA"]
+    return pd.DataFrame(
+        {
+            "report_date": ["03/31/2026"] * n,
+            "matchup": ["MIL@BOS"] * n,
+            "team": [teams_pool[i % len(teams_pool)] for i in range(n)],
+            "player_name": list(statuses.keys()),
+            "status": list(statuses.values()),
+            "reason": ["Injury"] * n,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests for _build (pure logic, no I/O)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSchema(unittest.TestCase):
+    """Output schema is always correct."""
+
+    def setUp(self):
+        from src.availability.availability_table import AvailabilityTableBuilder
+
+        _reset_singleton(AvailabilityTableBuilder)
+        self.AvailabilityTableBuilder = AvailabilityTableBuilder
+
+    def tearDown(self):
+        _reset_singleton(self.AvailabilityTableBuilder)
+
+    def _builder(self):
+        return self.AvailabilityTableBuilder(
+            save_mode="local", report_date="2026-03-31"
+        )
+
+    def test_required_columns_present(self):
+        b = self._builder()
+        df = b._build(_make_injury_df(), _make_players_df())
+        for col in (
+            "game_date",
+            "team",
+            "team_id",
+            "person_id",
+            "player_slug",
+            "status",
+            "play_probability",
+            "is_available",
+        ):
+            self.assertIn(col, df.columns, f"Missing column: {col}")
+
+    def test_is_available_is_boolean(self):
+        b = self._builder()
+        df = b._build(_make_injury_df(), _make_players_df())
+        self.assertTrue(
+            df["is_available"].dtype == bool or df["is_available"].dtype == object,
+            "is_available should be bool-like",
+        )
+
+    def test_play_probability_in_unit_interval(self):
+        b = self._builder()
+        df = b._build(_make_injury_df(), _make_players_df())
+        self.assertTrue((df["play_probability"] >= 0).all())
+        self.assertTrue((df["play_probability"] <= 1).all())
+
+    def test_game_date_is_correct(self):
+        b = self._builder()
+        df = b._build(_make_injury_df(), _make_players_df())
+        expected_date = pd.Timestamp("2026-03-31")
+        self.assertTrue((df["game_date"] == expected_date).all())
+
+
+class TestBuildCounts(unittest.TestCase):
+    """Row counts and available/unavailable splits."""
+
+    def setUp(self):
+        from src.availability.availability_table import AvailabilityTableBuilder
+
+        _reset_singleton(AvailabilityTableBuilder)
+        self.AvailabilityTableBuilder = AvailabilityTableBuilder
+
+    def tearDown(self):
+        _reset_singleton(self.AvailabilityTableBuilder)
+
+    def _builder(self, threshold=None):
+        kwargs = {"save_mode": "local", "report_date": "2026-03-31"}
+        if threshold is not None:
+            kwargs["availability_threshold"] = threshold
+        return self.AvailabilityTableBuilder(**kwargs)
+
+    def test_all_players_appear_in_output(self):
+        """Every player in the roster should have a row in the output."""
+        players = _make_players_df()
+        b = self._builder()
+        df = b._build(_make_injury_df(), players)
+        self.assertEqual(len(df), len(players))
+
+    def test_injured_players_override_baseline(self):
+        """Players in the injury report get their injury status, not 'Available'."""
+        b = self._builder()
+        df = b._build(_make_injury_df(), _make_players_df())
+        giannis = df[df["person_id"] == 1]
+        self.assertFalse(giannis.empty)
+        self.assertEqual(giannis.iloc[0]["status"], "Out")
+
+    def test_unlisted_players_are_available(self):
+        """Players absent from the injury report default to Available."""
+        b = self._builder()
+        df = b._build(_make_injury_df(), _make_players_df())
+        # LeBron (id=3) and Curry (id=4) are not in the injury report
+        for pid in (3, 4):
+            row = df[df["person_id"] == pid]
+            self.assertFalse(row.empty)
+            self.assertEqual(row.iloc[0]["status"], "Available")
+
+    def test_out_player_is_unavailable(self):
+        """A player with status Out should have is_available=False."""
+        b = self._builder()
+        df = b._build(_make_injury_df(), _make_players_df())
+        giannis = df[df["person_id"] == 1]
+        self.assertFalse(bool(giannis.iloc[0]["is_available"]))
+
+    def test_available_player_is_available(self):
+        """A player not on the report should have is_available=True."""
+        b = self._builder()
+        df = b._build(_make_injury_df(), _make_players_df())
+        lebron = df[df["person_id"] == 3]
+        self.assertTrue(bool(lebron.iloc[0]["is_available"]))
+
+    def test_threshold_changes_questionable_classification(self):
+        """With threshold=0.60, a Questionable player (p=0.50) is unavailable."""
+        injury = _make_injury_df({"Antetokounmpo,Giannis": "Questionable"})
+        # Threshold below Questionable probability → available
+        b_low = self._builder(threshold=0.40)
+        df_low = b_low._build(injury, _make_players_df())
+        giannis_low = df_low[df_low["person_id"] == 1]
+        self.assertTrue(bool(giannis_low.iloc[0]["is_available"]))
+
+        _reset_singleton(self.AvailabilityTableBuilder)
+        # Threshold above Questionable probability → unavailable
+        b_high = self._builder(threshold=0.60)
+        df_high = b_high._build(injury, _make_players_df())
+        giannis_high = df_high[df_high["person_id"] == 1]
+        self.assertFalse(bool(giannis_high.iloc[0]["is_available"]))
+
+
+class TestBuildEdgeCases(unittest.TestCase):
+    """Edge cases: empty inputs, all injured, single player."""
+
+    def setUp(self):
+        from src.availability.availability_table import AvailabilityTableBuilder
+
+        _reset_singleton(AvailabilityTableBuilder)
+        self.AvailabilityTableBuilder = AvailabilityTableBuilder
+
+    def tearDown(self):
+        _reset_singleton(self.AvailabilityTableBuilder)
+
+    def _builder(self):
+        return self.AvailabilityTableBuilder(
+            save_mode="local", report_date="2026-03-31"
+        )
+
+    def test_empty_injury_report_all_available(self):
+        """When the injury report is empty everyone defaults to Available."""
+        b = self._builder()
+        players = _make_players_df()
+        empty_injury = pd.DataFrame(
+            columns=[
+                "report_date",
+                "matchup",
+                "team",
+                "player_name",
+                "status",
+                "reason",
+            ]
+        )
+        df = b._build(empty_injury, players)
+        self.assertEqual(len(df), len(players))
+        self.assertTrue((df["status"] == "Available").all())
+        self.assertTrue(df["is_available"].all())
+
+    def test_empty_players_returns_empty(self):
+        """An empty players roster returns an empty DataFrame."""
+        b = self._builder()
+        empty_players = pd.DataFrame(columns=_make_players_df().columns)
+        df = b._build(_make_injury_df(), empty_players)
+        self.assertTrue(df.empty)
+
+    def test_all_players_injured_out(self):
+        """When every player is Out, is_available is False for all."""
+        players = _make_players_df()
+        statuses = {
+            "Antetokounmpo,Giannis": "Out",
+            "Brown,Jaylen": "Out",
+            "James,LeBron": "Out",
+            "Curry,Stephen": "Out",
+        }
+        injury = _make_injury_df(statuses)
+        b = self._builder()
+        df = b._build(injury, players)
+        self.assertFalse(df["is_available"].any())
+
+    def test_play_probability_for_out_player(self):
+        """Out players receive the correct calibrated probability."""
+        injury = _make_injury_df({"Antetokounmpo,Giannis": "Out"})
+        b = self._builder()
+        df = b._build(injury, _make_players_df())
+        giannis = df[df["person_id"] == 1]
+        self.assertAlmostEqual(
+            giannis.iloc[0]["play_probability"],
+            AVAILABILITY_PLAY_PROBABILITY["Out"],
+        )
+
+    def test_play_probability_for_unlisted_player(self):
+        """Unlisted players receive the Available probability."""
+        b = self._builder()
+        df = b._build(_make_injury_df(), _make_players_df())
+        lebron = df[df["person_id"] == 3]
+        self.assertAlmostEqual(
+            lebron.iloc[0]["play_probability"],
+            AVAILABILITY_PLAY_PROBABILITY["Available"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests for run() (mocked I/O)
+# ---------------------------------------------------------------------------
+
+
+class TestAvailabilityTableBuilderRun(unittest.TestCase):
+    """run() wires I/O correctly."""
+
+    def setUp(self):
+        from src.availability.availability_table import AvailabilityTableBuilder
+
+        _reset_singleton(AvailabilityTableBuilder)
+        self.AvailabilityTableBuilder = AvailabilityTableBuilder
+
+    def tearDown(self):
+        _reset_singleton(self.AvailabilityTableBuilder)
+
+    def _builder(self):
+        return self.AvailabilityTableBuilder(
+            save_mode="local", report_date="2026-03-31"
+        )
+
+    @patch("src.availability.availability_table.save_database")
+    @patch("src.availability.availability_table.load_data")
+    def test_run_calls_save_database(self, mock_load, mock_save):
+        """run() calls save_database with the built DataFrame."""
+        from common.io_utils import InjuryReportFileName, PlayersFileName
+
+        def _side_effect(filename, mode):
+            if filename == InjuryReportFileName:
+                return _make_injury_df()
+            if filename == PlayersFileName:
+                return _make_players_df()
+            return pd.DataFrame()
+
+        mock_load.side_effect = _side_effect
+
+        b = self._builder()
+        result = b.run()
+
+        mock_save.assert_called_once()
+        saved_df = mock_save.call_args[0][0]
+        self.assertIsInstance(saved_df, pd.DataFrame)
+        self.assertFalse(saved_df.empty)
+
+    @patch("src.availability.availability_table.save_database")
+    @patch("src.availability.availability_table.load_data")
+    def test_run_returns_dataframe(self, mock_load, mock_save):
+        """run() returns the availability DataFrame."""
+        from common.io_utils import InjuryReportFileName, PlayersFileName
+
+        def _side_effect(filename, mode):
+            if filename == InjuryReportFileName:
+                return _make_injury_df()
+            if filename == PlayersFileName:
+                return _make_players_df()
+            return pd.DataFrame()
+
+        mock_load.side_effect = _side_effect
+
+        b = self._builder()
+        result = b.run()
+
+        self.assertIsInstance(result, pd.DataFrame)
+        self.assertFalse(result.empty)
+
+    @patch("src.availability.availability_table.save_database")
+    @patch("src.availability.availability_table.load_data")
+    def test_run_does_not_save_when_players_empty(self, mock_load, mock_save):
+        """run() skips save when the players table is empty."""
+        from common.io_utils import InjuryReportFileName, PlayersFileName
+
+        def _side_effect(filename, mode):
+            if filename == InjuryReportFileName:
+                return _make_injury_df()
+            if filename == PlayersFileName:
+                return pd.DataFrame()
+            return pd.DataFrame()
+
+        mock_load.side_effect = _side_effect
+
+        b = self._builder()
+        result = b.run()
+
+        mock_save.assert_not_called()
+        self.assertTrue(result.empty)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_fantasy_model_integration.py
+++ b/tests/test_fantasy_model_integration.py
@@ -3,33 +3,41 @@ import os
 import tempfile
 from src.training.train import UnifiedModelTrainer
 
+# This test loads real CSV files from databases/ — skip when they are absent (e.g. CI)
+_HAS_REAL_DATA = os.path.exists("databases/nba_boxscore_basic.csv")
+
+
+@unittest.skipUnless(_HAS_REAL_DATA, "Real CSV data not available (CI environment)")
 class TestFantasyModelIntegration(unittest.TestCase):
     def setUp(self):
         # Create a temporary directory for the model artifact
         self.temp_dir = tempfile.TemporaryDirectory()
         self.model_path = os.path.join(self.temp_dir.name, "integration_test_model.pkl")
-        
+
         # Initialize trainer with real data loading (no mocks)
         # We assume the CSV files exist in the 'databases/' folder as per workspace structure
-        self.trainer = UnifiedModelTrainer(target="fantasy_points", model_path=self.model_path, save_mode="local")
+        self.trainer = UnifiedModelTrainer(
+            target="fantasy_points", model_path=self.model_path, save_mode="local"
+        )
 
     def tearDown(self):
         self.temp_dir.cleanup()
 
     def test_run_pipeline_real_data(self):
         print("\nRunning integration test with REAL data... this may take a while.")
-        
+
         # Run pipeline with minimal iterations for speed, but using real data
         # tune_params=False to skip the long hyperparameter tuning step
         self.trainer.run(tune_params=False, n_iter=1)
-        
+
         # Check if model file was created
         self.assertTrue(os.path.exists(self.model_path))
-        
+
         # Check if feature columns were populated (meaning data was loaded and processed)
         self.assertTrue(len(self.trainer.feature_cols) > 0)
-        
+
         print(f"Integration test passed. Model saved to {self.model_path}")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_fantasy_model_pipeline.py
+++ b/tests/test_fantasy_model_pipeline.py
@@ -7,55 +7,68 @@ import tempfile
 from src.training.train import UnifiedModelTrainer as ModelTrainer
 from common.io_utils import BoxscoreFileName, AdvancedBoxscoreFileName, PlayersFileName
 
+
 class TestFantasyModelPipeline(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
         self.model_path = os.path.join(self.temp_dir.name, "model.pkl")
-        self.trainer = ModelTrainer(model_path=self.model_path, save_mode="local")
-        
+        # persist_model writes metrics CSV to databases/ — create it inside temp dir
+        self.databases_dir = os.path.join(self.temp_dir.name, "databases")
+        os.makedirs(self.databases_dir, exist_ok=True)
+        self._orig_dir = os.getcwd()
+        os.chdir(self.temp_dir.name)
+        self.trainer = ModelTrainer(
+            target="fantasy_points", model_path=self.model_path, save_mode="local"
+        )
+
         # Mock data
-        self.box = pd.DataFrame({
-            'gameId': [f'002230000{i}' for i in range(1, 21)],
-            'personId': ['p1'] * 10 + ['p2'] * 10,
-            'teamId': ['t1'] * 20,
-            'points': np.random.randint(10, 30, 20),
-            'reboundsTotal': np.random.randint(2, 10, 20),
-            'rebounds': np.random.randint(2, 10, 20),
-            'assists': np.random.randint(2, 10, 20),
-            'steals': np.random.randint(0, 3, 20),
-            'blocks': np.random.randint(0, 3, 20),
-            'turnovers': np.random.randint(0, 5, 20),
-            'threePointersMade': np.random.randint(0, 5, 20),
-            'fieldGoalsMade': np.random.randint(5, 15, 20),
-            'fieldGoalsAttempted': np.random.randint(10, 20, 20),
-            'threePointersAttempted': np.random.randint(2, 10, 20),
-            'freeThrowsMade': np.random.randint(0, 5, 20),
-            'freeThrowsAttempted': np.random.randint(0, 5, 20),
-            'minutes': ['30:00'] * 20,
-            'position': ['G'] * 20,
-            'game_date': pd.date_range(start='2023-01-01', periods=20).astype(str),
-            'home_team_id': ['t1'] * 20,
-            'visitor_team_id': ['t2'] * 20,
-            'possessions': [100] * 20
-        })
-        
-        self.adv = pd.DataFrame({
-            'gameId': [f'002230000{i}' for i in range(1, 21)],
-            'personId': ['p1'] * 10 + ['p2'] * 10,
-            'teamId': ['t1'] * 20,
-            'offensive_rating': [100] * 20
-        })
-        
-        self.players = pd.DataFrame({
-            'person_id': ['p1', 'p2'],
-            'position': ['G', 'F']
-        })
+        self.box = pd.DataFrame(
+            {
+                "gameId": [f"002230000{i}" for i in range(1, 21)],
+                "personId": ["p1"] * 10 + ["p2"] * 10,
+                "teamId": ["t1"] * 20,
+                "points": np.random.randint(10, 30, 20),
+                "reboundsTotal": np.random.randint(2, 10, 20),
+                "rebounds": np.random.randint(2, 10, 20),
+                "assists": np.random.randint(2, 10, 20),
+                "steals": np.random.randint(0, 3, 20),
+                "blocks": np.random.randint(0, 3, 20),
+                "turnovers": np.random.randint(0, 5, 20),
+                "threePointersMade": np.random.randint(0, 5, 20),
+                "fieldGoalsMade": np.random.randint(5, 15, 20),
+                "fieldGoalsAttempted": np.random.randint(10, 20, 20),
+                "threePointersAttempted": np.random.randint(2, 10, 20),
+                "freeThrowsMade": np.random.randint(0, 5, 20),
+                "freeThrowsAttempted": np.random.randint(0, 5, 20),
+                "minutes": ["30:00"] * 20,
+                "position": ["G"] * 20,
+                "game_date": pd.date_range(start="2023-01-01", periods=20).astype(str),
+                "home_team_id": ["t1"] * 20,
+                "visitor_team_id": ["t2"] * 20,
+                "possessions": [100] * 20,
+            }
+        )
+
+        self.adv = pd.DataFrame(
+            {
+                "gameId": [f"002230000{i}" for i in range(1, 21)],
+                "personId": ["p1"] * 10 + ["p2"] * 10,
+                "teamId": ["t1"] * 20,
+                "offensiveRating": [100] * 20,
+                "usagePercentage": [0.25] * 20,
+                "trueShootingPercentage": [0.55] * 20,
+                "effectiveFieldGoalPercentage": [0.50] * 20,
+                "assistToTurnover": [2.0] * 20,
+            }
+        )
+
+        self.players = pd.DataFrame({"person_id": ["p1", "p2"], "position": ["G", "F"]})
 
     def tearDown(self):
+        os.chdir(self._orig_dir)
         self.temp_dir.cleanup()
 
-    @patch('src.train_fantasy_model.load_data')
-    @patch('src.train_fantasy_model.key_stats_fantasy', {'points': 'Points (raw)'})
+    @patch("common.training_helpers.load_data")
     def test_run_pipeline(self, mock_load_data):
         # Setup mock return values
         def side_effect(filename, mode):
@@ -66,17 +79,18 @@ class TestFantasyModelPipeline(unittest.TestCase):
             elif filename == PlayersFileName:
                 return self.players
             return pd.DataFrame()
-            
+
         mock_load_data.side_effect = side_effect
-        
+
         # Run pipeline with minimal iterations for speed
         self.trainer.run(tune_params=False, n_iter=1)
-        
+
         # Check if model file was created
         self.assertTrue(os.path.exists(self.model_path))
-        
+
         # Check if feature columns were populated
         self.assertTrue(len(self.trainer.feature_cols) > 0)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -2,103 +2,110 @@ import unittest
 import pandas as pd
 import numpy as np
 from common.feature_engineering import (
-    merge_data, preprocess_data, create_historical_features,
-    normalize_features, compute_rolling_stats, encode_categorical_features,
-    get_feature_cols
+    merge_data,
+    preprocess_data,
+    create_historical_features,
+    normalize_features,
+    compute_rolling_stats,
+    encode_categorical_features,
+    get_feature_cols,
 )
+
 
 class TestFeatureEngineering(unittest.TestCase):
     def setUp(self):
         # Create sample dataframes
-        self.box = pd.DataFrame({
-            'gameId': ['0022300001', '0022300002', '0022300003'],
-            'personId': ['p1', 'p1', 'p2'],
-            'teamId': ['t1', 't1', 't2'],
-            'points': [10, 20, 15],
-            'minutes': ['20:00', '30:00', '25:00'],
-            'game_date': ['2023-01-01', '2023-01-02', '2023-01-01'],
-            'home_team_id': ['t1', 't2', 't2'],
-            'visitor_team_id': ['t2', 't1', 't1'],
-            'possessions': [100, 100, 100],
-            'position': ['G', 'G', 'F']
-        })
-        
-        self.adv = pd.DataFrame({
-            'gameId': ['0022300001', '0022300002', '0022300003'],
-            'personId': ['p1', 'p1', 'p2'],
-            'teamId': ['t1', 't1', 't2'],
-            'offensive_rating': [100, 110, 105]
-        })
-        
-        self.players = pd.DataFrame({
-            'person_id': ['p1', 'p2'],
-            'position': ['G', 'F']
-        })
-        
-        self.key_stats = {'points': 'Points (raw)', 'assists': 'Assists (engineering)'}
+        self.box = pd.DataFrame(
+            {
+                "gameId": ["0022300001", "0022300002", "0022300003"],
+                "personId": ["p1", "p1", "p2"],
+                "teamId": ["t1", "t1", "t2"],
+                "points": [10, 20, 15],
+                "minutes": ["20:00", "30:00", "25:00"],
+                "game_date": ["2023-01-01", "2023-01-02", "2023-01-01"],
+                "home_team_id": ["t1", "t2", "t2"],
+                "visitor_team_id": ["t2", "t1", "t1"],
+                "possessions": [100, 100, 100],
+                "position": ["G", "G", "F"],
+            }
+        )
+
+        self.adv = pd.DataFrame(
+            {
+                "gameId": ["0022300001", "0022300002", "0022300003"],
+                "personId": ["p1", "p1", "p2"],
+                "teamId": ["t1", "t1", "t2"],
+                "offensive_rating": [100, 110, 105],
+            }
+        )
+
+        self.players = pd.DataFrame({"person_id": ["p1", "p2"], "position": ["G", "F"]})
+
+        self.key_stats = {"points": "Points (raw)", "assists": "Assists (engineering)"}
 
     def test_merge_data(self):
         df = merge_data(self.box, self.adv, self.players)
-        self.assertIn('offensive_rating', df.columns)
-        self.assertIn('position_player', df.columns)
+        self.assertIn("offensive_rating", df.columns)
+        self.assertIn("position_player", df.columns)
         self.assertEqual(len(df), 3)
 
     def test_preprocess_data(self):
         df = merge_data(self.box, self.adv, self.players)
         df = preprocess_data(df)
-        
-        self.assertTrue(pd.api.types.is_float_dtype(df['minutes']))
-        self.assertTrue(pd.api.types.is_datetime64_any_dtype(df['game_date']))
-        self.assertIn('position_group', df.columns)
-        self.assertIn('season', df.columns)
-        self.assertIn('is_home', df.columns)
-        self.assertIn('opponent', df.columns)
+
+        self.assertTrue(pd.api.types.is_float_dtype(df["minutes"]))
+        self.assertTrue(pd.api.types.is_datetime64_any_dtype(df["game_date"]))
+        self.assertIn("position_group", df.columns)
+        self.assertIn("season", df.columns)
+        self.assertIn("is_home", df.columns)
+        self.assertIn("opponent", df.columns)
 
     def test_create_historical_features(self):
         df = merge_data(self.box, self.adv, self.players)
         df = preprocess_data(df)
         # Ensure we have enough data for historical features or handle NaNs
         df = create_historical_features(df)
-        
-        self.assertIn('avg_pts_opp_position_last_10', df.columns)
-        self.assertIn('avg_pts_opp_position_last_20', df.columns)
-        self.assertIn('avg_pts_opp_position_all', df.columns)
+
+        self.assertIn("avg_points_opp_position_last_10", df.columns)
+        self.assertIn("avg_points_opp_position_last_20", df.columns)
+        self.assertIn("avg_points_opp_position_all", df.columns)
 
     def test_normalize_features(self):
         df = merge_data(self.box, self.adv, self.players)
         df = preprocess_data(df)
         df = normalize_features(df, self.key_stats)
-        
-        self.assertIn('points_per36', df.columns)
-        self.assertIn('points_per_poss', df.columns)
-        
+
+        self.assertIn("points_per36", df.columns)
+        self.assertIn("points_per_poss", df.columns)
+
         # Check calculation: 10 points in 20 mins -> 18 per 36
         row1 = df.iloc[0]
-        self.assertAlmostEqual(row1['points_per36'], 10 / 20 * 36)
+        self.assertAlmostEqual(row1["points_per36"], 10 / 20 * 36)
 
     def test_compute_rolling_stats(self):
         df = merge_data(self.box, self.adv, self.players)
         df = preprocess_data(df)
         df = normalize_features(df, self.key_stats)
         df = compute_rolling_stats(df, self.key_stats, windows=[2])
-        
-        self.assertIn('points_per36_rolling_2', df.columns)
-        self.assertIn('points_per_poss_rolling_2', df.columns)
+
+        self.assertIn("points_per36_rolling_2", df.columns)
+        self.assertIn("points_per_poss_rolling_2", df.columns)
 
     def test_encode_categorical_features(self):
-        df = pd.DataFrame({'pos': ['A', 'B', 'A']})
-        df, encoded_cols, _ = encode_categorical_features(df, ['pos'])
-        
-        self.assertIn('pos_A', df.columns)
-        self.assertIn('pos_B', df.columns)
-        self.assertIn('pos_A', encoded_cols)
+        df = pd.DataFrame({"pos": ["A", "B", "A"]})
+        df, encoded_cols = encode_categorical_features(df, ["pos"])
+
+        self.assertIn("pos_A", df.columns)
+        self.assertIn("pos_B", df.columns)
+        self.assertIn("pos_A", encoded_cols)
 
     def test_get_feature_cols(self):
         cols = get_feature_cols(self.key_stats, rolling_periods=[5])
-        self.assertIn('points_per36_rolling_5', cols)
-        self.assertIn('points_per_poss_rolling_5', cols)
-        self.assertIn('assists_per36', cols)
-        self.assertIn('assists_per_poss', cols)
+        self.assertIn("points_per36_rolling_5", cols)
+        self.assertIn("points_per_poss_rolling_5", cols)
+        self.assertIn("assists_per36", cols)
+        self.assertIn("assists_per_poss", cols)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_injury_normalizer.py
+++ b/tests/test_injury_normalizer.py
@@ -1,0 +1,220 @@
+"""
+Unit tests for src/availability/injury_normalizer.py
+
+Tests cover:
+  - normalize_status: exact matches, alias matches (GTD, DND, NWT, DNP),
+    case-insensitivity, unknown values, empty/None input
+  - play_probability: all canonical levels, unknown input
+  - normalize_report: column additions, value preservation, empty DataFrame guard
+"""
+
+import unittest
+import pandas as pd
+
+from src.availability.injury_normalizer import (
+    normalize_status,
+    play_probability,
+    normalize_report,
+)
+from common.constants import AVAILABILITY_PLAY_PROBABILITY
+
+
+class TestNormalizeStatus(unittest.TestCase):
+    """normalize_status maps raw strings to canonical levels."""
+
+    # ------------------------------------------------------------------ exact
+    def test_out_exact(self):
+        self.assertEqual(normalize_status("Out"), "Out")
+
+    def test_out_uppercase(self):
+        self.assertEqual(normalize_status("OUT"), "Out")
+
+    def test_doubtful_exact(self):
+        self.assertEqual(normalize_status("Doubtful"), "Doubtful")
+
+    def test_questionable_exact(self):
+        self.assertEqual(normalize_status("Questionable"), "Questionable")
+
+    def test_probable_exact(self):
+        self.assertEqual(normalize_status("Probable"), "Probable")
+
+    def test_available_exact(self):
+        self.assertEqual(normalize_status("Available"), "Available")
+
+    # ------------------------------------------------------------------ aliases
+    def test_dnp_maps_to_out(self):
+        self.assertEqual(normalize_status("DNP"), "Out")
+
+    def test_dnd_maps_to_out(self):
+        self.assertEqual(normalize_status("DND"), "Out")
+
+    def test_nwt_maps_to_out(self):
+        self.assertEqual(normalize_status("NWT"), "Out")
+
+    def test_gtd_maps_to_questionable(self):
+        self.assertEqual(normalize_status("GTD"), "Questionable")
+
+    def test_game_time_decision_maps_to_questionable(self):
+        self.assertEqual(normalize_status("GAME TIME DECISION"), "Questionable")
+
+    def test_active_maps_to_available(self):
+        self.assertEqual(normalize_status("ACTIVE"), "Available")
+
+    def test_inactive_maps_to_out(self):
+        self.assertEqual(normalize_status("INACTIVE"), "Out")
+
+    def test_suspended_maps_to_out(self):
+        self.assertEqual(normalize_status("SUSPENDED"), "Out")
+
+    # ------------------------------------------------------------------ case
+    def test_mixed_case_out(self):
+        self.assertEqual(normalize_status("out"), "Out")
+
+    def test_mixed_case_probable(self):
+        self.assertEqual(normalize_status("probable"), "Probable")
+
+    # ------------------------------------------------------------------ edge
+    def test_unknown_returns_questionable(self):
+        self.assertEqual(normalize_status("MYSTERY_STATUS"), "Questionable")
+
+    def test_empty_string_returns_questionable(self):
+        self.assertEqual(normalize_status(""), "Questionable")
+
+    def test_none_returns_questionable(self):
+        self.assertEqual(normalize_status(None), "Questionable")
+
+    def test_whitespace_only_returns_questionable(self):
+        self.assertEqual(normalize_status("   "), "Questionable")
+
+
+class TestPlayProbability(unittest.TestCase):
+    """play_probability returns calibrated floats for canonical statuses."""
+
+    def test_out_probability(self):
+        self.assertEqual(play_probability("Out"), AVAILABILITY_PLAY_PROBABILITY["Out"])
+
+    def test_doubtful_probability(self):
+        self.assertEqual(
+            play_probability("Doubtful"), AVAILABILITY_PLAY_PROBABILITY["Doubtful"]
+        )
+
+    def test_questionable_probability(self):
+        self.assertEqual(
+            play_probability("Questionable"),
+            AVAILABILITY_PLAY_PROBABILITY["Questionable"],
+        )
+
+    def test_probable_probability(self):
+        self.assertEqual(
+            play_probability("Probable"), AVAILABILITY_PLAY_PROBABILITY["Probable"]
+        )
+
+    def test_available_probability(self):
+        self.assertEqual(
+            play_probability("Available"), AVAILABILITY_PLAY_PROBABILITY["Available"]
+        )
+
+    def test_probabilities_are_ordered(self):
+        """Out < Doubtful < Questionable < Probable < Available."""
+        probs = [
+            play_probability("Out"),
+            play_probability("Doubtful"),
+            play_probability("Questionable"),
+            play_probability("Probable"),
+            play_probability("Available"),
+        ]
+        self.assertEqual(probs, sorted(probs))
+
+    def test_all_probabilities_in_unit_interval(self):
+        for status in ("Out", "Doubtful", "Questionable", "Probable", "Available"):
+            p = play_probability(status)
+            self.assertGreaterEqual(p, 0.0)
+            self.assertLessEqual(p, 1.0)
+
+    def test_unknown_status_returns_half(self):
+        self.assertEqual(play_probability("UNKNOWN"), 0.50)
+
+
+class TestNormalizeReport(unittest.TestCase):
+    """normalize_report enriches a raw injury DataFrame."""
+
+    def _make_raw_df(self):
+        return pd.DataFrame(
+            {
+                "report_date": ["03/31/2026", "03/31/2026", "03/31/2026"],
+                "matchup": ["MIL@BOS", "MIL@BOS", "LAL@GSW"],
+                "team": ["MIL", "BOS", "LAL"],
+                "player_name": [
+                    "Antetokounmpo,Giannis",
+                    "Brown,Jaylen",
+                    "James,LeBron",
+                ],
+                "status": ["OUT", "GTD", "PROBABLE"],
+                "reason": ["Knee", "Hamstring", ""],
+            }
+        )
+
+    # ------------------------------------------------------------------ columns
+    def test_raw_status_column_preserved(self):
+        df = normalize_report(self._make_raw_df())
+        self.assertIn("raw_status", df.columns)
+
+    def test_status_column_canonical(self):
+        df = normalize_report(self._make_raw_df())
+        self.assertIn("status", df.columns)
+        valid = {"Out", "Doubtful", "Questionable", "Probable", "Available"}
+        for val in df["status"]:
+            self.assertIn(val, valid, f"Unexpected canonical status: {val!r}")
+
+    def test_play_probability_column_added(self):
+        df = normalize_report(self._make_raw_df())
+        self.assertIn("play_probability", df.columns)
+
+    # ------------------------------------------------------------------ values
+    def test_out_row_has_low_probability(self):
+        df = normalize_report(self._make_raw_df())
+        out_rows = df[df["status"] == "Out"]
+        self.assertFalse(out_rows.empty)
+        self.assertTrue((out_rows["play_probability"] < 0.20).all())
+
+    def test_gtd_maps_to_questionable_in_dataframe(self):
+        df = normalize_report(self._make_raw_df())
+        # Second row was "GTD"
+        self.assertEqual(df.loc[1, "status"], "Questionable")
+        self.assertEqual(df.loc[1, "raw_status"], "GTD")
+
+    def test_probable_row_has_high_probability(self):
+        df = normalize_report(self._make_raw_df())
+        prob_rows = df[df["status"] == "Probable"]
+        self.assertFalse(prob_rows.empty)
+        self.assertTrue((prob_rows["play_probability"] >= 0.80).all())
+
+    def test_row_count_unchanged(self):
+        raw = self._make_raw_df()
+        df = normalize_report(raw)
+        self.assertEqual(len(df), len(raw))
+
+    # ------------------------------------------------------------------ edge
+    def test_empty_dataframe_returns_empty(self):
+        empty = pd.DataFrame(
+            columns=[
+                "report_date",
+                "matchup",
+                "team",
+                "player_name",
+                "status",
+                "reason",
+            ]
+        )
+        result = normalize_report(empty)
+        self.assertTrue(result.empty)
+
+    def test_original_dataframe_not_mutated(self):
+        raw = self._make_raw_df()
+        original_statuses = raw["status"].tolist()
+        normalize_report(raw)
+        self.assertEqual(raw["status"].tolist(), original_statuses)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_injury_report_collector.py
+++ b/tests/test_injury_report_collector.py
@@ -1,0 +1,838 @@
+"""
+Unit tests for src/data_collectors/get_injury_report.py
+
+Strategy
+--------
+All HTTP traffic is mocked with unittest.mock so no real network calls are made.
+The PDF is synthesised as a minimal valid PDF byte string so pdfplumber can parse
+it — no extra test dependency (reportlab, fpdf, …) is required.
+
+Tests cover:
+  - _resolve_pdf_url: picks last valid URL, raises when none found, stops on first 404
+  - _parse_pdf: correctly parses player records from synthesised PDF text
+  - run: end-to-end happy path (mocked HTTP + mocked save_database)
+  - Singleton reset between tests
+"""
+
+import io
+import datetime
+import textwrap
+import unittest
+from unittest.mock import patch, MagicMock, call
+
+import pandas as pd
+
+# Reset SingletonMeta state between tests so each test gets a fresh instance.
+from common.singleton_meta import SingletonMeta
+
+
+def _reset_singleton(cls):
+    """Remove a class from the SingletonMeta registry."""
+    if cls in SingletonMeta._instances:
+        del SingletonMeta._instances[cls]
+
+
+# ---------------------------------------------------------------------------
+# Minimal in-memory PDF builder
+# We build a PDF that contains exactly the text we want pdfplumber to see.
+# The structure is the bare minimum that pdfplumber accepts.
+# ---------------------------------------------------------------------------
+
+
+def _build_minimal_pdf(text_lines: list[str]) -> bytes:
+    """
+    Return a valid PDF byte string whose single page contains *text_lines*.
+    Uses only core PDF operators — no external library needed.
+    """
+
+    # Encode each line as a PDF text-show command
+    def _escape(s: str) -> str:
+        return s.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+
+    lines_pdf = "\n".join(
+        f"BT /F1 10 Tf 30 {700 - i * 14} Td ({_escape(line)}) Tj ET"
+        for i, line in enumerate(text_lines)
+    )
+
+    stream = textwrap.dedent(f"""\
+        {lines_pdf}
+    """).encode()
+
+    stream_len = len(stream)
+
+    body = (
+        b"%PDF-1.4\n"
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+        b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n"
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R "
+        b"/MediaBox [0 0 612 792] "
+        b"/Contents 4 0 R "
+        b"/Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n"
+    )
+
+    stream_obj = (
+        b"4 0 obj\n"
+        + f"<< /Length {stream_len} >>\n".encode()
+        + b"stream\n"
+        + stream
+        + b"\nendstream\nendobj\n"
+        b"5 0 obj\n"
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\n"
+        b"endobj\n"
+    )
+
+    xref_offset = len(body) + len(stream_obj)
+    trailer = (
+        b"xref\n0 6\n"
+        b"0000000000 65535 f \n"
+        b"0000000009 00000 n \n"
+        b"0000000058 00000 n \n"
+        b"0000000115 00000 n \n"
+        b"0000000266 00000 n \n"
+        b"0000000999 00000 n \n"
+        b"trailer\n<< /Size 6 /Root 1 0 R >>\n"
+        + f"startxref\n{xref_offset}\n%%EOF\n".encode()
+    )
+
+    return body + stream_obj + trailer
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_200_response(content: bytes = b"") -> MagicMock:
+    r = MagicMock()
+    r.status_code = 200
+    r.content = content
+    r.raise_for_status = MagicMock()
+    return r
+
+
+def _make_404_response() -> MagicMock:
+    r = MagicMock()
+    r.status_code = 404
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveUrl(unittest.TestCase):
+    """_resolve_pdf_url picks the last URL that returns HTTP 200."""
+
+    def setUp(self):
+        from src.data_collectors.get_injury_report import InjuryReportCollector
+
+        _reset_singleton(InjuryReportCollector)
+        self.InjuryReportCollector = InjuryReportCollector
+
+    def tearDown(self):
+        _reset_singleton(self.InjuryReportCollector)
+
+    @patch("src.data_collectors.get_injury_report.requests.head")
+    def test_returns_last_valid_url(self, mock_head):
+        """Returns the last hour that had a 200 before the first 404."""
+        # First two hours succeed, third fails → last valid is index 1
+        mock_head.side_effect = [
+            _make_200_response(),
+            _make_200_response(),
+            _make_404_response(),
+        ]
+
+        collector = self.InjuryReportCollector(
+            save_mode="local", report_date="2026-03-31"
+        )
+        url = collector._resolve_pdf_url()
+        self.assertIn("2026-03-31", url)
+        # Should have tried exactly 3 hours (2 success + 1 failure)
+        self.assertEqual(mock_head.call_count, 3)
+
+    @patch("src.data_collectors.get_injury_report.requests.head")
+    def test_raises_when_first_hour_is_404(self, mock_head):
+        """FileNotFoundError raised when no hour at all returns 200."""
+        mock_head.return_value = _make_404_response()
+
+        collector = self.InjuryReportCollector(
+            save_mode="local", report_date="2026-03-31"
+        )
+        with self.assertRaises(FileNotFoundError):
+            collector._resolve_pdf_url()
+
+    @patch("src.data_collectors.get_injury_report.requests.head")
+    def test_single_valid_hour(self, mock_head):
+        """Works correctly when only the first hour is valid."""
+        mock_head.side_effect = [_make_200_response(), _make_404_response()]
+
+        collector = self.InjuryReportCollector(
+            save_mode="local", report_date="2026-03-31"
+        )
+        url = collector._resolve_pdf_url()
+        self.assertIsNotNone(url)
+        self.assertEqual(mock_head.call_count, 2)
+
+
+class TestParsePdf(unittest.TestCase):
+    """_parse_pdf returns correctly structured DataFrames.
+
+    Strategy: mock pdfplumber.open so we control exactly what text the parser
+    sees, without needing a real PDF file or an external PDF-generation library.
+    """
+
+    def setUp(self):
+        from src.data_collectors.get_injury_report import InjuryReportCollector
+
+        _reset_singleton(InjuryReportCollector)
+        self.InjuryReportCollector = InjuryReportCollector
+        self.today = datetime.datetime.now(datetime.timezone.utc).strftime("%m/%d/%Y")
+
+    def tearDown(self):
+        _reset_singleton(self.InjuryReportCollector)
+
+    def _collector(self):
+        today_iso = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
+        return self.InjuryReportCollector(save_mode="local", report_date=today_iso)
+
+    def _mock_pdf(self, text_lines: list[str]):
+        """Return a context-manager mock that yields a PDF with one page."""
+        page = MagicMock()
+        page.extract_text.return_value = "\n".join(text_lines)
+
+        pdf_cm = MagicMock()
+        pdf_cm.__enter__ = MagicMock(return_value=pdf_cm)
+        pdf_cm.__exit__ = MagicMock(return_value=False)
+        pdf_cm.pages = [page]
+        return pdf_cm
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_parses_player_record(self, mock_pdf_open, mock_get):
+        """A well-formed page produces the expected player record."""
+        mock_get.return_value = _make_200_response(b"fake-pdf-bytes")
+        mock_pdf_open.return_value = self._mock_pdf(
+            [
+                f"{self.today} 06:00(ET) MIL@BOS MilwaukeeBucks Antetokounmpo,Giannis Out Knee",
+            ]
+        )
+
+        collector = self._collector()
+        df = collector._parse_pdf("https://fake.url/report.pdf")
+
+        self.assertFalse(df.empty, "DataFrame should not be empty")
+        self.assertIn("player_name", df.columns)
+        self.assertIn("status", df.columns)
+        self.assertIn("team", df.columns)
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_output_columns_present(self, mock_pdf_open, mock_get):
+        """All expected output columns are present even for a minimal record."""
+        mock_get.return_value = _make_200_response(b"fake-pdf-bytes")
+        mock_pdf_open.return_value = self._mock_pdf(
+            [
+                f"{self.today} 02:00(ET) LAL@GSW LosAngelesLakers James,LeBron Out Rest",
+            ]
+        )
+
+        collector = self._collector()
+        df = collector._parse_pdf("https://fake.url/report.pdf")
+
+        for col in [
+            "report_date",
+            "matchup",
+            "team",
+            "player_name",
+            "status",
+            "reason",
+        ]:
+            self.assertIn(col, df.columns, f"Missing column: {col}")
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_empty_pdf_returns_empty_dataframe(self, mock_pdf_open, mock_get):
+        """A PDF page with no player lines returns an empty DataFrame."""
+        mock_get.return_value = _make_200_response(b"fake-pdf-bytes")
+        mock_pdf_open.return_value = self._mock_pdf(["Page header only"])
+
+        collector = self._collector()
+        df = collector._parse_pdf("https://fake.url/report.pdf")
+
+        self.assertTrue(df.empty or len(df) == 0)
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_multiple_players_parsed(self, mock_pdf_open, mock_get):
+        """Multiple player lines on the same page are all parsed."""
+        mock_get.return_value = _make_200_response(b"fake-pdf-bytes")
+        mock_pdf_open.return_value = self._mock_pdf(
+            [
+                f"{self.today} 06:00(ET) MIL@BOS MilwaukeeBucks Antetokounmpo,Giannis Out Knee",
+                "BostonCeltics Brown,Jaylen Questionable Hamstring",
+            ]
+        )
+
+        collector = self._collector()
+        df = collector._parse_pdf("https://fake.url/report.pdf")
+
+        self.assertGreaterEqual(len(df), 1)
+
+
+class TestInjuryReportCollectorRun(unittest.TestCase):
+    """run() end-to-end: resolve URL → parse PDF → save."""
+
+    def setUp(self):
+        from src.data_collectors.get_injury_report import InjuryReportCollector
+
+        _reset_singleton(InjuryReportCollector)
+        self.InjuryReportCollector = InjuryReportCollector
+        self.today = datetime.datetime.now(datetime.timezone.utc).strftime("%m/%d/%Y")
+        self.today_iso = datetime.datetime.now(datetime.timezone.utc).strftime(
+            "%Y-%m-%d"
+        )
+
+    def tearDown(self):
+        _reset_singleton(self.InjuryReportCollector)
+
+    def _parsed_df(self) -> pd.DataFrame:
+        """A minimal non-empty DataFrame as if _parse_pdf returned it."""
+        return pd.DataFrame(
+            [
+                {
+                    "report_date": self.today,
+                    "matchup": "BOS@MIA",
+                    "team": "BOS",
+                    "player_name": "Tatum,Jayson",
+                    "status": "Out",
+                    "reason": "Ankle",
+                }
+            ]
+        )
+
+    @patch("src.data_collectors.get_injury_report.save_database")
+    @patch("src.data_collectors.get_injury_report.requests.head")
+    def test_run_saves_dataframe(self, mock_head, mock_save):
+        """run() calls save_database with a non-empty DataFrame."""
+        mock_head.side_effect = [_make_200_response(), _make_404_response()]
+
+        collector = self.InjuryReportCollector(
+            save_mode="local", report_date=self.today_iso
+        )
+        # Mock _parse_pdf at the instance level so we control the returned records
+        collector._parse_pdf = MagicMock(return_value=self._parsed_df())
+
+        collector.run()
+
+        mock_save.assert_called_once()
+        saved_df = mock_save.call_args[0][0]
+        self.assertIsInstance(saved_df, pd.DataFrame)
+        self.assertFalse(saved_df.empty)
+
+    @patch("src.data_collectors.get_injury_report.save_database")
+    @patch("src.data_collectors.get_injury_report.requests.head")
+    def test_run_raises_when_no_pdf_found(self, mock_head, mock_save):
+        """run() propagates FileNotFoundError when no PDF URL resolves."""
+        mock_head.return_value = _make_404_response()
+
+        collector = self.InjuryReportCollector(
+            save_mode="local", report_date=self.today_iso
+        )
+        with self.assertRaises(FileNotFoundError):
+            collector.run()
+
+        mock_save.assert_not_called()
+
+    @patch("src.data_collectors.get_injury_report.save_database")
+    @patch("src.data_collectors.get_injury_report.requests.head")
+    def test_run_returns_empty_without_saving_on_empty_pdf(self, mock_head, mock_save):
+        """run() does not call save_database when the PDF has no records."""
+        mock_head.side_effect = [_make_200_response(), _make_404_response()]
+
+        collector = self.InjuryReportCollector(
+            save_mode="local", report_date=self.today_iso
+        )
+        # _parse_pdf returns empty — nothing to save
+        collector._parse_pdf = MagicMock(
+            return_value=pd.DataFrame(
+                columns=[
+                    "report_date",
+                    "matchup",
+                    "team",
+                    "player_name",
+                    "status",
+                    "reason",
+                ]
+            )
+        )
+
+        df = collector.run()
+
+        mock_save.assert_not_called()
+        self.assertTrue(df.empty)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: real NBA PDF format
+# ---------------------------------------------------------------------------
+
+# Verbatim lines extracted from Injury-Report_2025-03-30_08PM.pdf
+# (via pdfplumber page.extract_text()).  Used as a fixture to verify the
+# parser against the actual format the NBA publishes.
+_REAL_PDF_PAGE_1 = [
+    "Injury Report: 03/30/25 08:30 PM",
+    "GameDate GameTime Matchup Team PlayerName CurrentStatus Reason",
+    "03/30/2025 03:30(ET) LAC@CLE LAClippers BaldwinJr.,Patrick Out GLeague-Two-Way",
+    "Christie,Cam Out NotWithTeam",
+    "Flowers,Trentyn Out GLeague-Two-Way",
+    "Injury/Illness-RightKnee;Injury",
+    "Leonard,Kawhi Out",
+    "Management",
+    "Lundy,Seth Out GLeague-Two-Way",
+    "Injury/Illness-LeftHamstring;",
+    "Miller,Jordan Out",
+    "Tendinopathy",
+    "ClevelandCavaliers Bates,Emoni Out GLeague-Two-Way",
+    "Jerome,Ty Out Injury/Illness-LeftKnee;Tendinitis",
+    "Tyson,Jaylon Out Injury/Illness-LeftKnee;BoneBruise",
+    "06:00(ET) POR@NYK PortlandTrailBlazers Ayton,Deandre Out Injury/Illness-LeftCalf;Strain",
+    "Injury/Illness-RightKnee;",
+    "Grant,Jerami Out",
+    "Inflammation",
+    "Henderson,Scoot Out ConcussionProtocol",
+    "McGowens,Bryce Out Injury/Illness-RightRib;Fracture",
+    "Injury/Illness-RightForearm;",
+    "Simons,Anfernee Available",
+    "Soreness",
+    "WilliamsIII,Robert Out Injury/Illness-LeftKnee;Injury",
+    "Page1of11",
+]
+
+# Expected rows for page 1 (player_name, team, matchup, status, reason)
+_EXPECTED_PAGE_1 = [
+    ("BaldwinJr.,Patrick", "LAClippers", "LAC@CLE", "Out", "GLeague-Two-Way"),
+    ("Christie,Cam", "LAClippers", "LAC@CLE", "Out", "NotWithTeam"),
+    (
+        "Flowers,Trentyn",
+        "LAClippers",
+        "LAC@CLE",
+        "Out",
+        "GLeague-Two-Way Injury/Illness-RightKnee;Injury",
+    ),
+    ("Leonard,Kawhi", "LAClippers", "LAC@CLE", "Out", "Management"),
+    (
+        "Lundy,Seth",
+        "LAClippers",
+        "LAC@CLE",
+        "Out",
+        "GLeague-Two-Way Injury/Illness-LeftHamstring;",
+    ),
+    ("Miller,Jordan", "LAClippers", "LAC@CLE", "Out", "Tendinopathy"),
+    ("Bates,Emoni", "ClevelandCavaliers", "LAC@CLE", "Out", "GLeague-Two-Way"),
+    (
+        "Jerome,Ty",
+        "ClevelandCavaliers",
+        "LAC@CLE",
+        "Out",
+        "Injury/Illness-LeftKnee;Tendinitis",
+    ),
+    (
+        "Tyson,Jaylon",
+        "ClevelandCavaliers",
+        "LAC@CLE",
+        "Out",
+        "Injury/Illness-LeftKnee;BoneBruise",
+    ),
+    (
+        "Ayton,Deandre",
+        "PortlandTrailBlazers",
+        "POR@NYK",
+        "Out",
+        "Injury/Illness-LeftCalf;Strain Injury/Illness-RightKnee;",
+    ),
+    ("Grant,Jerami", "PortlandTrailBlazers", "POR@NYK", "Out", "Inflammation"),
+    ("Henderson,Scoot", "PortlandTrailBlazers", "POR@NYK", "Out", "ConcussionProtocol"),
+    (
+        "McGowens,Bryce",
+        "PortlandTrailBlazers",
+        "POR@NYK",
+        "Out",
+        "Injury/Illness-RightRib;Fracture Injury/Illness-RightForearm;",
+    ),
+    ("Simons,Anfernee", "PortlandTrailBlazers", "POR@NYK", "Available", "Soreness"),
+    (
+        "WilliamsIII,Robert",
+        "PortlandTrailBlazers",
+        "POR@NYK",
+        "Out",
+        "Injury/Illness-LeftKnee;Injury",
+    ),
+]
+
+# Additional lines that test NOTYETSUBMITTED handling and next-day games
+_REAL_PDF_NOTYETSUBMITTED = [
+    "Injury Report: 03/30/25 08:30 PM",
+    "GameDate GameTime Matchup Team PlayerName CurrentStatus Reason",
+    "03/31/2025 07:00(ET) LAC@ORL LAClippers NOTYETSUBMITTED",
+    "CharlotteHornets NOTYETSUBMITTED",
+    "Page2of11",
+]
+
+
+class TestParsePdfRealFormat(unittest.TestCase):
+    """_parse_pdf handles the real NBA injury-report PDF structure."""
+
+    def setUp(self):
+        from src.data_collectors.get_injury_report import InjuryReportCollector
+
+        _reset_singleton(InjuryReportCollector)
+        self.InjuryReportCollector = InjuryReportCollector
+
+    def tearDown(self):
+        _reset_singleton(self.InjuryReportCollector)
+
+    def _collector(self, date_iso: str):
+        return self.InjuryReportCollector(save_mode="local", report_date=date_iso)
+
+    def _mock_pdf(self, text_lines: list[str]):
+        page = MagicMock()
+        page.extract_text.return_value = "\n".join(text_lines)
+        pdf_cm = MagicMock()
+        pdf_cm.__enter__ = MagicMock(return_value=pdf_cm)
+        pdf_cm.__exit__ = MagicMock(return_value=False)
+        pdf_cm.pages = [page]
+        return pdf_cm
+
+    # ------------------------------------------------------------------
+    # Page-1 fixture tests
+    # ------------------------------------------------------------------
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_page1_row_count(self, mock_pdf_open, mock_get):
+        """Parser produces exactly the expected number of rows from page 1."""
+        mock_get.return_value = _make_200_response(b"fake")
+        mock_pdf_open.return_value = self._mock_pdf(_REAL_PDF_PAGE_1)
+
+        collector = self._collector("2025-03-30")
+        df = collector._parse_pdf("https://fake.url/report.pdf")
+
+        self.assertEqual(len(df), len(_EXPECTED_PAGE_1), msg=df.to_string())
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_page1_player_names(self, mock_pdf_open, mock_get):
+        """All player names from page 1 are parsed correctly."""
+        mock_get.return_value = _make_200_response(b"fake")
+        mock_pdf_open.return_value = self._mock_pdf(_REAL_PDF_PAGE_1)
+
+        collector = self._collector("2025-03-30")
+        df = collector._parse_pdf("https://fake.url/report.pdf")
+
+        actual_names = df["player_name"].tolist()
+        expected_names = [r[0] for r in _EXPECTED_PAGE_1]
+        self.assertEqual(
+            actual_names,
+            expected_names,
+            msg=df[["player_name", "team", "matchup"]].to_string(),
+        )
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_page1_teams(self, mock_pdf_open, mock_get):
+        """Team names are correctly assigned — team changes trigger on CamelCase tokens."""
+        mock_get.return_value = _make_200_response(b"fake")
+        mock_pdf_open.return_value = self._mock_pdf(_REAL_PDF_PAGE_1)
+
+        collector = self._collector("2025-03-30")
+        df = collector._parse_pdf("https://fake.url/report.pdf")
+
+        actual_teams = df["team"].tolist()
+        expected_teams = [r[1] for r in _EXPECTED_PAGE_1]
+        self.assertEqual(
+            actual_teams, expected_teams, msg=df[["player_name", "team"]].to_string()
+        )
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_page1_matchups(self, mock_pdf_open, mock_get):
+        """Matchup context switches correctly when a new time+matchup line appears."""
+        mock_get.return_value = _make_200_response(b"fake")
+        mock_pdf_open.return_value = self._mock_pdf(_REAL_PDF_PAGE_1)
+
+        collector = self._collector("2025-03-30")
+        df = collector._parse_pdf("https://fake.url/report.pdf")
+
+        actual_matchups = df["matchup"].tolist()
+        expected_matchups = [r[2] for r in _EXPECTED_PAGE_1]
+        self.assertEqual(
+            actual_matchups,
+            expected_matchups,
+            msg=df[["player_name", "matchup"]].to_string(),
+        )
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_page1_statuses(self, mock_pdf_open, mock_get):
+        """Status values are extracted without contamination from reason tokens."""
+        mock_get.return_value = _make_200_response(b"fake")
+        mock_pdf_open.return_value = self._mock_pdf(_REAL_PDF_PAGE_1)
+
+        collector = self._collector("2025-03-30")
+        df = collector._parse_pdf("https://fake.url/report.pdf")
+
+        actual_statuses = df["status"].tolist()
+        expected_statuses = [r[3] for r in _EXPECTED_PAGE_1]
+        self.assertEqual(actual_statuses, expected_statuses)
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_page1_reasons_multiline(self, mock_pdf_open, mock_get):
+        """Multi-line reasons are joined correctly; team/matchup lines do not leak."""
+        mock_get.return_value = _make_200_response(b"fake")
+        mock_pdf_open.return_value = self._mock_pdf(_REAL_PDF_PAGE_1)
+
+        collector = self._collector("2025-03-30")
+        df = collector._parse_pdf("https://fake.url/report.pdf")
+
+        actual_reasons = df["reason"].tolist()
+        expected_reasons = [r[4] for r in _EXPECTED_PAGE_1]
+        self.assertEqual(
+            actual_reasons,
+            expected_reasons,
+            msg=df[["player_name", "reason"]].to_string(),
+        )
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_page_footer_not_in_reasons(self, mock_pdf_open, mock_get):
+        """Page footer tokens ('Page1of11') must not appear in any reason field."""
+        mock_get.return_value = _make_200_response(b"fake")
+        mock_pdf_open.return_value = self._mock_pdf(_REAL_PDF_PAGE_1)
+
+        collector = self._collector("2025-03-30")
+        df = collector._parse_pdf("https://fake.url/report.pdf")
+
+        for reason in df["reason"]:
+            self.assertNotIn(
+                "Page", reason, msg=f"Footer leaked into reason: {reason!r}"
+            )
+
+    # ------------------------------------------------------------------
+    # NOTYETSUBMITTED fixture tests
+    # ------------------------------------------------------------------
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_notyetsubmitted_produces_no_rows(self, mock_pdf_open, mock_get):
+        """Teams marked NOTYETSUBMITTED generate zero player rows."""
+        mock_get.return_value = _make_200_response(b"fake")
+        mock_pdf_open.return_value = self._mock_pdf(_REAL_PDF_NOTYETSUBMITTED)
+
+        collector = self._collector("2025-03-31")
+        df = collector._parse_pdf("https://fake.url/report.pdf")
+
+        self.assertEqual(len(df), 0, msg=df.to_string())
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_notyetsubmitted_not_in_player_name(self, mock_pdf_open, mock_get):
+        """'NOTYETSUBMITTED' must never appear as a player_name value."""
+        mock_get.return_value = _make_200_response(b"fake")
+        mock_pdf_open.return_value = self._mock_pdf(_REAL_PDF_NOTYETSUBMITTED)
+
+        collector = self._collector("2025-03-31")
+        df = collector._parse_pdf("https://fake.url/report.pdf")
+
+        if not df.empty:
+            self.assertNotIn("NOTYETSUBMITTED", df["player_name"].values)
+
+
+# ---------------------------------------------------------------------------
+# Regression fixture: bare matchup lines (page-break artifact)
+# Mirrors the real lines from Injury-Report_2026-04-02_10_00AM.pdf that
+# previously caused continuation-swallowing bugs.
+# ---------------------------------------------------------------------------
+
+# Page 1 ending with Stewart,Isaiah followed by a bare PHX@CHA matchup line
+_BARE_MATCHUP_PAGE_1 = [
+    "04/02/2026 07:00(ET) MIN@DET MinnesotaTimberwolves Edwards,Anthony Questionable PatellofemoralPainSyndrome",
+    "DetroitPistons Stewart,Isaiah Out Injury/Illness-LeftCalf;Strain",
+    "PHX@CHA PhoenixSuns Coffey,Amir Out Injury/Illness-LeftAnkle;Sprain",
+    "Injury/Illness-RightKnee;Injury",
+    "Page1of4",
+]
+
+# Page straddle: Wade,Dean ends page 1; page 2 opens with a bare NOP@POR line
+_BARE_MATCHUP_PAGE_STRADDLE = [
+    # page 1
+    "04/02/2026 10:00(ET) CLE@GSW ClevelandCavaliers Wade,Dean Out Injury/Illness-RightAnkle;Sprain",
+    "GoldenStateWarriors NOTYETSUBMITTED",
+    "NOP@POR NewOrleansPelicans Matkovic,Karlo Questionable Injury/Illness-LowBack;Spasms",
+    "Page2of4",
+    "Injury Report: 04/02/26 10:00 AM",
+    # page 2 continuation of Matkovic
+    "Injury/Illness-RightSmallToe;Fracture",
+]
+
+_EXPECTED_BARE_PAGE_1 = [
+    (
+        "Edwards,Anthony",
+        "MinnesotaTimberwolves",
+        "MIN@DET",
+        "Questionable",
+        "PatellofemoralPainSyndrome",
+    ),
+    (
+        "Stewart,Isaiah",
+        "DetroitPistons",
+        "MIN@DET",
+        "Out",
+        "Injury/Illness-LeftCalf;Strain",
+    ),
+    (
+        "Coffey,Amir",
+        "PhoenixSuns",
+        "PHX@CHA",
+        "Out",
+        "Injury/Illness-LeftAnkle;Sprain Injury/Illness-RightKnee;Injury",
+    ),
+]
+
+_EXPECTED_BARE_STRADDLE = [
+    (
+        "Wade,Dean",
+        "ClevelandCavaliers",
+        "CLE@GSW",
+        "Out",
+        "Injury/Illness-RightAnkle;Sprain",
+    ),
+    (
+        "Matkovic,Karlo",
+        "NewOrleansPelicans",
+        "NOP@POR",
+        "Questionable",
+        "Injury/Illness-LowBack;Spasms Injury/Illness-RightSmallToe;Fracture",
+    ),
+]
+
+
+class TestParsePdfBareMatchup(unittest.TestCase):
+    """Regression tests for bare matchup lines (no time prefix, page-break artifact).
+
+    These lines — e.g. 'PHX@CHA PhoenixSuns Coffey,Amir Out ...' — appear
+    when pdfplumber merges the time token from the end of the previous line.
+    They must be treated as a new matchup context, not as a reason continuation.
+    """
+
+    def setUp(self):
+        from src.data_collectors.get_injury_report import InjuryReportCollector
+
+        _reset_singleton(InjuryReportCollector)
+        self.InjuryReportCollector = InjuryReportCollector
+
+    def tearDown(self):
+        _reset_singleton(self.InjuryReportCollector)
+
+    def _collector(self, date_iso: str):
+        return self.InjuryReportCollector(save_mode="local", report_date=date_iso)
+
+    def _mock_pdf(self, pages: list[list[str]]):
+        """Multi-page mock: each inner list is one page."""
+        mock_pages = []
+        for lines in pages:
+            page = MagicMock()
+            page.extract_text.return_value = "\n".join(lines)
+            mock_pages.append(page)
+        pdf_cm = MagicMock()
+        pdf_cm.__enter__ = MagicMock(return_value=pdf_cm)
+        pdf_cm.__exit__ = MagicMock(return_value=False)
+        pdf_cm.pages = mock_pages
+        return pdf_cm
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_bare_matchup_row_count(self, mock_pdf_open, mock_get):
+        """Bare matchup line starts a new matchup — correct number of rows."""
+        mock_get.return_value = _make_200_response(b"fake")
+        mock_pdf_open.return_value = self._mock_pdf([_BARE_MATCHUP_PAGE_1])
+        df = self._collector("2026-04-02")._parse_pdf("https://fake.url/report.pdf")
+        self.assertEqual(len(df), len(_EXPECTED_BARE_PAGE_1), msg=df.to_string())
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_bare_matchup_player_names(self, mock_pdf_open, mock_get):
+        """Players after a bare matchup line are parsed with correct names."""
+        mock_get.return_value = _make_200_response(b"fake")
+        mock_pdf_open.return_value = self._mock_pdf([_BARE_MATCHUP_PAGE_1])
+        df = self._collector("2026-04-02")._parse_pdf("https://fake.url/report.pdf")
+        self.assertEqual(
+            df["player_name"].tolist(), [r[0] for r in _EXPECTED_BARE_PAGE_1]
+        )
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_bare_matchup_matchup_context(self, mock_pdf_open, mock_get):
+        """Bare matchup line resets the matchup context for subsequent players."""
+        mock_get.return_value = _make_200_response(b"fake")
+        mock_pdf_open.return_value = self._mock_pdf([_BARE_MATCHUP_PAGE_1])
+        df = self._collector("2026-04-02")._parse_pdf("https://fake.url/report.pdf")
+        self.assertEqual(df["matchup"].tolist(), [r[2] for r in _EXPECTED_BARE_PAGE_1])
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_bare_matchup_prior_player_reason_clean(self, mock_pdf_open, mock_get):
+        """The player before the bare matchup line does NOT get the matchup appended to its reason."""
+        mock_get.return_value = _make_200_response(b"fake")
+        mock_pdf_open.return_value = self._mock_pdf([_BARE_MATCHUP_PAGE_1])
+        df = self._collector("2026-04-02")._parse_pdf("https://fake.url/report.pdf")
+        stewart_reason = df.loc[df["player_name"] == "Stewart,Isaiah", "reason"].iloc[0]
+        self.assertNotIn("PHX@CHA", stewart_reason)
+        self.assertNotIn("Coffey", stewart_reason)
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_bare_matchup_continuation_reason(self, mock_pdf_open, mock_get):
+        """A continuation line after a bare matchup player is joined to that player's reason."""
+        mock_get.return_value = _make_200_response(b"fake")
+        mock_pdf_open.return_value = self._mock_pdf([_BARE_MATCHUP_PAGE_1])
+        df = self._collector("2026-04-02")._parse_pdf("https://fake.url/report.pdf")
+        coffey_reason = df.loc[df["player_name"] == "Coffey,Amir", "reason"].iloc[0]
+        self.assertIn("Injury/Illness-RightKnee;Injury", coffey_reason)
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_page_straddle_row_count(self, mock_pdf_open, mock_get):
+        """Page-straddle scenario: correct row count across two pages."""
+        mock_get.return_value = _make_200_response(b"fake")
+        mock_pdf_open.return_value = self._mock_pdf([_BARE_MATCHUP_PAGE_STRADDLE])
+        df = self._collector("2026-04-02")._parse_pdf("https://fake.url/report.pdf")
+        self.assertEqual(len(df), len(_EXPECTED_BARE_STRADDLE), msg=df.to_string())
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_page_straddle_wade_reason_clean(self, mock_pdf_open, mock_get):
+        """Wade,Dean's reason must not include any NOP@POR or Matkovic content."""
+        mock_get.return_value = _make_200_response(b"fake")
+        mock_pdf_open.return_value = self._mock_pdf([_BARE_MATCHUP_PAGE_STRADDLE])
+        df = self._collector("2026-04-02")._parse_pdf("https://fake.url/report.pdf")
+        wade_reason = df.loc[df["player_name"] == "Wade,Dean", "reason"].iloc[0]
+        self.assertNotIn("NOP@POR", wade_reason)
+        self.assertNotIn("Matkovic", wade_reason)
+
+    @patch("src.data_collectors.get_injury_report.requests.get")
+    @patch("src.data_collectors.get_injury_report.pdfplumber.open")
+    def test_page_straddle_matkovic_reason_joined(self, mock_pdf_open, mock_get):
+        """Matkovic's reason continuation from the next page is joined correctly."""
+        mock_get.return_value = _make_200_response(b"fake")
+        mock_pdf_open.return_value = self._mock_pdf([_BARE_MATCHUP_PAGE_STRADDLE])
+        df = self._collector("2026-04-02")._parse_pdf("https://fake.url/report.pdf")
+        matkovic_reason = df.loc[df["player_name"] == "Matkovic,Karlo", "reason"].iloc[
+            0
+        ]
+        self.assertIn("Injury/Illness-RightSmallToe;Fracture", matkovic_reason)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_unified_predictor_availability.py
+++ b/tests/test_unified_predictor_availability.py
@@ -1,0 +1,531 @@
+"""
+Unit tests for the availability filtering logic in UnifiedPredictor.get_future_games_players()
+and the confidence score computation in UnifiedPredictor.persist().
+
+Key behaviour under test (availability filter):
+  - Only players with play_probability < PREDICTION_EXCLUDE_THRESHOLD are excluded.
+    By default that means only 'Out' players (play_probability=0.02).
+  - 'Doubtful' players (play_probability=0.15) are now included and receive a prediction.
+  - 'Questionable' players (play_probability=0.50) are included.
+  - Players not present in the availability table default to play_probability=0.97 (Available)
+    and are always included.
+  - When the availability DataFrame is empty, all roster players are included.
+
+Key behaviour under test (confidence score):
+  confidence = play_probability × stability × sample_conf
+  stability   = 1 - min(volatility / CONFIDENCE_MAX_VOLATILITY, 1.0)
+  sample_conf = min(games_played / CONFIDENCE_SAMPLE_SIZE_CAP, 1.0)
+"""
+
+import datetime
+import unittest
+from unittest.mock import patch, MagicMock
+
+import pandas as pd
+import numpy as np
+
+from common.singleton_meta import SingletonMeta
+from common.constants import (
+    PREDICTION_EXCLUDE_THRESHOLD,
+    CONFIDENCE_MAX_VOLATILITY,
+    CONFIDENCE_SAMPLE_SIZE_CAP,
+)
+
+
+def _reset_singleton(cls):
+    if cls in SingletonMeta._instances:
+        del SingletonMeta._instances[cls]
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+GAME_DATE = "2026-04-02"
+
+
+def _make_schedule_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "gameId": ["0022600001"],
+            "gameDate": [GAME_DATE],
+            "homeTeam_teamId": [1610612747],  # LAL
+            "awayTeam_teamId": [1610612744],  # GSW
+        }
+    )
+
+
+def _make_players_df() -> pd.DataFrame:
+    """4 players: 2 LAL, 2 GSW."""
+    return pd.DataFrame(
+        {
+            "person_id": [1, 2, 3, 4],
+            "player_slug": [
+                "lebron-james",
+                "anthony-davis",
+                "stephen-curry",
+                "klay-thompson",
+            ],
+            "team_id": [1610612747, 1610612747, 1610612744, 1610612744],
+            "position": ["F", "C", "G", "G"],
+        }
+    )
+
+
+def _make_availability_df(rows: list[dict]) -> pd.DataFrame:
+    """
+    Each row dict should have: person_id, play_probability, status (optional).
+    Missing keys are filled with defaults.
+    """
+    defaults = {"game_date": GAME_DATE, "is_available": True, "status": "Available"}
+    filled = [{**defaults, **r} for r in rows]
+    return pd.DataFrame(filled)
+
+
+# ---------------------------------------------------------------------------
+# Helper to call get_future_games_players() in isolation
+# ---------------------------------------------------------------------------
+
+
+def _call_get_future_games_players(availability_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Instantiate a fresh UnifiedPredictor (singleton reset each call) and invoke
+    get_future_games_players with fully mocked I/O.
+    """
+    from src.predictors.unified_predictor import UnifiedPredictor
+    from common.io_utils import (
+        ScheduleFileName,
+        PlayersFileName,
+        AvailabilityFileName,
+        BoxscoreFileName,
+        AdvancedBoxscoreFileName,
+    )
+
+    _reset_singleton(UnifiedPredictor)
+
+    with patch("src.predictors.unified_predictor.load_model_artifact"):
+        predictor = UnifiedPredictor(
+            target="fantasy_points",
+            save_mode="local",
+            date=GAME_DATE,
+            model_path="/fake/path",
+        )
+
+    data_map = {
+        ScheduleFileName: _make_schedule_df(),
+        PlayersFileName: _make_players_df(),
+        AvailabilityFileName: availability_df,
+        BoxscoreFileName: pd.DataFrame(),
+        AdvancedBoxscoreFileName: pd.DataFrame(),
+    }
+
+    return predictor.get_future_games_players(data_map)
+
+
+# ---------------------------------------------------------------------------
+# Helper to call persist() in isolation
+# ---------------------------------------------------------------------------
+
+
+def _make_predictor():
+    from src.predictors.unified_predictor import UnifiedPredictor
+
+    _reset_singleton(UnifiedPredictor)
+    with patch("src.predictors.unified_predictor.load_model_artifact"):
+        return UnifiedPredictor(
+            target="fantasy_points",
+            save_mode="local",
+            date=GAME_DATE,
+            model_path="/fake/path",
+        )
+
+
+def _make_pred_rows(person_ids, predictions, measure=2):
+    """Minimal prediction rows DataFrame."""
+    return pd.DataFrame(
+        {
+            "gameId": ["G1"] * len(person_ids),
+            "gameDate": [GAME_DATE] * len(person_ids),
+            "teamId": [1] * len(person_ids),
+            "opponentId": [2] * len(person_ids),
+            "personId": person_ids,
+            "player_slug": [f"player-{i}" for i in person_ids],
+            "Measure": [measure] * len(person_ids),
+            "Predictions": predictions,
+        }
+    )
+
+
+def _call_persist(predictor, pred_rows, vol_rows, availability_df, games_played_df):
+    """Call persist() with save_predictions mocked out; return the saved DataFrame."""
+    import common.constants as c
+    from src.predictors.unified_predictor import UnifiedPredictor
+
+    saved = {}
+
+    def capture(df, table_name, mode):
+        saved["df"] = df.copy()
+
+    combined = pd.concat([pred_rows, vol_rows], ignore_index=True)
+
+    with patch(
+        "src.predictors.unified_predictor.save_predictions", side_effect=capture
+    ):
+        predictor.persist(
+            predictions_df=combined,
+            availability_df=availability_df,
+            games_played_df=games_played_df,
+        )
+    return saved["df"]
+
+
+# ---------------------------------------------------------------------------
+# Tests — availability filter
+# ---------------------------------------------------------------------------
+
+
+class TestPredictorAvailabilityFilter(unittest.TestCase):
+    def tearDown(self):
+        from src.predictors.unified_predictor import UnifiedPredictor
+
+        _reset_singleton(UnifiedPredictor)
+
+    # ------------------------------------------------------------------
+    # PREDICTION_EXCLUDE_THRESHOLD sanity
+    # ------------------------------------------------------------------
+
+    def test_exclude_threshold_above_out(self):
+        """PREDICTION_EXCLUDE_THRESHOLD must be > Out probability (0.02)."""
+        self.assertGreater(PREDICTION_EXCLUDE_THRESHOLD, 0.02)
+
+    def test_exclude_threshold_below_doubtful(self):
+        """PREDICTION_EXCLUDE_THRESHOLD must be <= Doubtful probability (0.15)
+        so that Doubtful players are NOT excluded."""
+        self.assertLessEqual(PREDICTION_EXCLUDE_THRESHOLD, 0.15)
+
+    # ------------------------------------------------------------------
+    # Out players excluded
+    # ------------------------------------------------------------------
+
+    def test_out_player_excluded(self):
+        """A player with play_probability=0.02 (Out) must not appear in output."""
+        avail = _make_availability_df(
+            [
+                {"person_id": 1, "play_probability": 0.02, "status": "Out"},
+            ]
+        )
+        result = _call_get_future_games_players(avail)
+        self.assertNotIn(1, result["person_id"].values)
+
+    def test_out_player_excluded_other_players_present(self):
+        """Excluding one Out player must not affect the others."""
+        avail = _make_availability_df(
+            [
+                {"person_id": 1, "play_probability": 0.02, "status": "Out"},
+            ]
+        )
+        result = _call_get_future_games_players(avail)
+        present = set(result["person_id"].unique())
+        self.assertIn(2, present)
+        self.assertIn(3, present)
+        self.assertIn(4, present)
+
+    def test_multiple_out_players_excluded(self):
+        """Multiple Out players on the same team are all excluded."""
+        avail = _make_availability_df(
+            [
+                {"person_id": 1, "play_probability": 0.02, "status": "Out"},
+                {"person_id": 2, "play_probability": 0.02, "status": "Out"},
+            ]
+        )
+        result = _call_get_future_games_players(avail)
+        present = set(result["person_id"].unique())
+        self.assertNotIn(1, present)
+        self.assertNotIn(2, present)
+        self.assertIn(3, present)
+        self.assertIn(4, present)
+
+    # ------------------------------------------------------------------
+    # Doubtful / Questionable players included
+    # ------------------------------------------------------------------
+
+    def test_doubtful_player_included(self):
+        """A player with play_probability=0.15 (Doubtful) must appear in output."""
+        avail = _make_availability_df(
+            [
+                {"person_id": 1, "play_probability": 0.15, "status": "Doubtful"},
+            ]
+        )
+        result = _call_get_future_games_players(avail)
+        self.assertIn(1, result["person_id"].values)
+
+    def test_questionable_player_included(self):
+        """A player with play_probability=0.50 (Questionable) must appear in output."""
+        avail = _make_availability_df(
+            [
+                {"person_id": 3, "play_probability": 0.50, "status": "Questionable"},
+            ]
+        )
+        result = _call_get_future_games_players(avail)
+        self.assertIn(3, result["person_id"].values)
+
+    # ------------------------------------------------------------------
+    # Players not in / empty availability table
+    # ------------------------------------------------------------------
+
+    def test_player_not_in_availability_included(self):
+        """Players absent from the availability table are included (healthy by default)."""
+        avail = _make_availability_df([])
+        result = _call_get_future_games_players(avail)
+        self.assertEqual(set(result["person_id"].unique()), {1, 2, 3, 4})
+
+    def test_empty_availability_includes_all(self):
+        """When availability_df is completely empty, all roster players are included."""
+        result = _call_get_future_games_players(pd.DataFrame())
+        self.assertEqual(set(result["person_id"].unique()), {1, 2, 3, 4})
+
+    # ------------------------------------------------------------------
+    # Row count sanity
+    # ------------------------------------------------------------------
+
+    def test_row_count_one_out(self):
+        """With 1 Out player, output should have rows for 3 players."""
+        avail = _make_availability_df(
+            [
+                {"person_id": 1, "play_probability": 0.02, "status": "Out"},
+            ]
+        )
+        result = _call_get_future_games_players(avail)
+        self.assertEqual(len(result), 3)
+
+    def test_row_count_no_exclusions(self):
+        """With no Out players, all 4 players get a row."""
+        result = _call_get_future_games_players(pd.DataFrame())
+        self.assertEqual(len(result), 4)
+
+
+# ---------------------------------------------------------------------------
+# Tests — confidence score
+# ---------------------------------------------------------------------------
+
+
+class TestPredictorConfidence(unittest.TestCase):
+    """
+    Tests for persist() confidence computation.
+    Formula:
+        stability   = 1 - min(volatility / CONFIDENCE_MAX_VOLATILITY, 1.0)
+        sample_conf = min(games_played / CONFIDENCE_SAMPLE_SIZE_CAP, 1.0)
+        confidence  = play_probability × stability × sample_conf
+    """
+
+    def tearDown(self):
+        from src.predictors.unified_predictor import UnifiedPredictor
+
+        _reset_singleton(UnifiedPredictor)
+
+    def _run(self, play_prob, volatility, games_played):
+        """Run persist() for a single player and return their confidence value."""
+        predictor = _make_predictor()
+
+        pred_rows = _make_pred_rows([1], [30.0], measure=predictor.measure_prediction)
+        vol_rows = _make_pred_rows(
+            [1], [volatility], measure=predictor.measure_volatility
+        )
+        avail_df = _make_availability_df(
+            [{"person_id": 1, "play_probability": play_prob}]
+        )
+        gp_df = pd.DataFrame({"personId": [1], "games_played": [games_played]})
+
+        result = _call_persist(predictor, pred_rows, vol_rows, avail_df, gp_df)
+        pred = result[result["Measure"] == predictor.measure_prediction]
+        return float(pred["confidence"].iloc[0])
+
+    # ------------------------------------------------------------------
+    # confidence column exists on prediction rows
+    # ------------------------------------------------------------------
+
+    def test_confidence_column_present(self):
+        """persist() output must have a 'confidence' column."""
+        predictor = _make_predictor()
+        pred_rows = _make_pred_rows([1], [20.0], measure=predictor.measure_prediction)
+        vol_rows = _make_pred_rows([1], [5.0], measure=predictor.measure_volatility)
+        avail_df = _make_availability_df([{"person_id": 1, "play_probability": 0.97}])
+        gp_df = pd.DataFrame({"personId": [1], "games_played": [30]})
+
+        result = _call_persist(predictor, pred_rows, vol_rows, avail_df, gp_df)
+        self.assertIn("confidence", result.columns)
+
+    # ------------------------------------------------------------------
+    # Volatility rows carry NaN confidence
+    # ------------------------------------------------------------------
+
+    def test_volatility_rows_have_nan_confidence(self):
+        """Volatility rows (Measure=4) must not have a confidence score."""
+        predictor = _make_predictor()
+        pred_rows = _make_pred_rows([1], [20.0], measure=predictor.measure_prediction)
+        vol_rows = _make_pred_rows([1], [5.0], measure=predictor.measure_volatility)
+        avail_df = _make_availability_df([{"person_id": 1, "play_probability": 0.97}])
+        gp_df = pd.DataFrame({"personId": [1], "games_played": [30]})
+
+        result = _call_persist(predictor, pred_rows, vol_rows, avail_df, gp_df)
+        vol = result[result["Measure"] == predictor.measure_volatility]
+        self.assertTrue(vol["confidence"].isna().all())
+
+    # ------------------------------------------------------------------
+    # Healthy, consistent, many games → near-max confidence
+    # ------------------------------------------------------------------
+
+    def test_healthy_consistent_veteran(self):
+        """play_prob=0.97, low vol=5, 70 games → high confidence."""
+        conf = self._run(play_prob=0.97, volatility=5.0, games_played=70)
+        stability = 1 - 5.0 / CONFIDENCE_MAX_VOLATILITY
+        sample_conf = 1.0
+        expected = round(0.97 * stability * sample_conf, 2)
+        self.assertAlmostEqual(conf, expected, places=2)
+        self.assertGreater(conf, 0.60)
+
+    # ------------------------------------------------------------------
+    # Questionable player → reduced by play_probability
+    # ------------------------------------------------------------------
+
+    def test_questionable_reduces_confidence(self):
+        """play_prob=0.50 halves confidence vs a healthy equivalent."""
+        conf_healthy = self._run(play_prob=0.97, volatility=5.0, games_played=70)
+        conf_questionable = self._run(play_prob=0.50, volatility=5.0, games_played=70)
+        self.assertLess(conf_questionable, conf_healthy)
+
+    # ------------------------------------------------------------------
+    # High volatility → reduced by stability factor
+    # ------------------------------------------------------------------
+
+    def test_high_volatility_reduces_confidence(self):
+        """High volatility (22) gives lower confidence than low volatility (5)."""
+        conf_low_vol = self._run(play_prob=0.97, volatility=5.0, games_played=70)
+        conf_high_vol = self._run(play_prob=0.97, volatility=22.0, games_played=70)
+        self.assertLess(conf_high_vol, conf_low_vol)
+
+    def test_volatility_at_cap_gives_zero_stability(self):
+        """Volatility at or above CONFIDENCE_MAX_VOLATILITY → stability=0 → confidence=0."""
+        conf = self._run(
+            play_prob=0.97, volatility=CONFIDENCE_MAX_VOLATILITY, games_played=70
+        )
+        self.assertEqual(conf, 0.0)
+
+    def test_volatility_above_cap_clamped(self):
+        """Volatility above cap should still give confidence=0, not negative."""
+        conf = self._run(
+            play_prob=0.97, volatility=CONFIDENCE_MAX_VOLATILITY + 10, games_played=70
+        )
+        self.assertEqual(conf, 0.0)
+
+    # ------------------------------------------------------------------
+    # Few games → reduced by sample_conf factor
+    # ------------------------------------------------------------------
+
+    def test_few_games_reduces_confidence(self):
+        """A player with 5 games has lower confidence than one with 50."""
+        conf_few = self._run(play_prob=0.97, volatility=5.0, games_played=5)
+        conf_many = self._run(play_prob=0.97, volatility=5.0, games_played=50)
+        self.assertLess(conf_few, conf_many)
+
+    def test_zero_games_gives_zero_confidence(self):
+        """0 games played → sample_conf=0 → confidence=0."""
+        conf = self._run(play_prob=0.97, volatility=5.0, games_played=0)
+        self.assertEqual(conf, 0.0)
+
+    def test_games_at_cap_saturates(self):
+        """games_played at CONFIDENCE_SAMPLE_SIZE_CAP and above give the same sample_conf=1."""
+        conf_at_cap = self._run(
+            play_prob=0.97, volatility=5.0, games_played=CONFIDENCE_SAMPLE_SIZE_CAP
+        )
+        conf_above_cap = self._run(
+            play_prob=0.97, volatility=5.0, games_played=CONFIDENCE_SAMPLE_SIZE_CAP + 30
+        )
+        self.assertAlmostEqual(conf_at_cap, conf_above_cap, places=2)
+
+    # ------------------------------------------------------------------
+    # Missing availability → defaults to 0.97
+    # ------------------------------------------------------------------
+
+    def test_missing_availability_defaults_to_healthy(self):
+        """Player absent from availability table gets play_probability=0.97."""
+        predictor = _make_predictor()
+        pred_rows = _make_pred_rows([1], [20.0], measure=predictor.measure_prediction)
+        vol_rows = _make_pred_rows([1], [5.0], measure=predictor.measure_volatility)
+        gp_df = pd.DataFrame({"personId": [1], "games_played": [30]})
+
+        # Pass empty availability
+        result_empty_avail = _call_persist(
+            predictor, pred_rows, vol_rows, pd.DataFrame(), gp_df
+        )
+
+        _reset_singleton(type(predictor))
+        predictor2 = _make_predictor()
+        avail_df = _make_availability_df([{"person_id": 1, "play_probability": 0.97}])
+        result_explicit_healthy = _call_persist(
+            predictor2, pred_rows, vol_rows, avail_df, gp_df
+        )
+
+        conf_empty = float(
+            result_empty_avail[
+                result_empty_avail["Measure"] == predictor.measure_prediction
+            ]["confidence"].iloc[0]
+        )
+        conf_healthy = float(
+            result_explicit_healthy[
+                result_explicit_healthy["Measure"] == predictor.measure_prediction
+            ]["confidence"].iloc[0]
+        )
+        self.assertAlmostEqual(conf_empty, conf_healthy, places=2)
+
+    # ------------------------------------------------------------------
+    # Missing volatility → worst-case stability (0)
+    # ------------------------------------------------------------------
+
+    def test_missing_volatility_gives_zero_confidence(self):
+        """NaN volatility (new player, < 5 games) → stability=0 → confidence=0."""
+        predictor = _make_predictor()
+        pred_rows = _make_pred_rows([1], [10.0], measure=predictor.measure_prediction)
+        vol_rows = _make_pred_rows([1], [np.nan], measure=predictor.measure_volatility)
+        avail_df = _make_availability_df([{"person_id": 1, "play_probability": 0.97}])
+        gp_df = pd.DataFrame({"personId": [1], "games_played": [10]})
+
+        result = _call_persist(predictor, pred_rows, vol_rows, avail_df, gp_df)
+        pred = result[result["Measure"] == predictor.measure_prediction]
+        self.assertEqual(float(pred["confidence"].iloc[0]), 0.0)
+
+    # ------------------------------------------------------------------
+    # Confidence is bounded [0, 1]
+    # ------------------------------------------------------------------
+
+    def test_confidence_bounded_between_0_and_1(self):
+        """Confidence must always be in [0.0, 1.0]."""
+        for play_prob, vol, games in [
+            (0.97, 0.0, 70),  # best case
+            (0.50, 12.0, 10),  # mid case
+            (0.15, 24.0, 3),  # near-worst case
+            (0.97, 30.0, 100),  # volatility above cap
+        ]:
+            conf = self._run(play_prob, vol, games)
+            self.assertGreaterEqual(conf, 0.0, f"conf<0 for {play_prob},{vol},{games}")
+            self.assertLessEqual(conf, 1.0, f"conf>1 for {play_prob},{vol},{games}")
+
+    # ------------------------------------------------------------------
+    # Negative predictions are clipped to 0
+    # ------------------------------------------------------------------
+
+    def test_negative_predictions_clipped(self):
+        """persist() must clip negative prediction values to 0."""
+        predictor = _make_predictor()
+        pred_rows = _make_pred_rows([1], [-3.5], measure=predictor.measure_prediction)
+        vol_rows = _make_pred_rows([1], [5.0], measure=predictor.measure_volatility)
+        avail_df = _make_availability_df([{"person_id": 1, "play_probability": 0.97}])
+        gp_df = pd.DataFrame({"personId": [1], "games_played": [30]})
+
+        result = _call_persist(predictor, pred_rows, vol_rows, avail_df, gp_df)
+        pred = result[result["Measure"] == predictor.measure_prediction]
+        self.assertEqual(float(pred["Predictions"].iloc[0]), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_unified_training.py
+++ b/tests/test_unified_training.py
@@ -3,73 +3,120 @@
 import unittest
 import os
 import tempfile
+import pandas as pd
+import numpy as np
+from unittest.mock import patch
 from src.training.train import UnifiedModelTrainer
+from common.io_utils import BoxscoreFileName, AdvancedBoxscoreFileName, PlayersFileName
+
+
+def _make_mock_data():
+    """Return (box, adv, players) DataFrames sufficient for the full training pipeline."""
+    n = 40  # enough rows for a meaningful train/test split
+    box = pd.DataFrame(
+        {
+            "gameId": [f"00223000{i:02d}" for i in range(n)],
+            "personId": [f"p{i % 4 + 1}" for i in range(n)],
+            "teamId": ["t1"] * (n // 2) + ["t2"] * (n // 2),
+            "points": np.random.randint(5, 35, n),
+            "reboundsTotal": np.random.randint(1, 12, n),
+            "rebounds": np.random.randint(1, 12, n),
+            "assists": np.random.randint(0, 10, n),
+            "steals": np.random.randint(0, 4, n),
+            "blocks": np.random.randint(0, 4, n),
+            "turnovers": np.random.randint(0, 6, n),
+            "threePointersMade": np.random.randint(0, 6, n),
+            "fieldGoalsMade": np.random.randint(3, 15, n),
+            "fieldGoalsAttempted": np.random.randint(8, 22, n),
+            "threePointersAttempted": np.random.randint(1, 10, n),
+            "freeThrowsMade": np.random.randint(0, 6, n),
+            "freeThrowsAttempted": np.random.randint(0, 8, n),
+            "minutes": ["28:00"] * n,
+            "position": ["G"] * n,
+            "game_date": pd.date_range(start="2023-01-01", periods=n).astype(str),
+            "home_team_id": ["t1"] * n,
+            "visitor_team_id": ["t2"] * n,
+            "possessions": [100] * n,
+        }
+    )
+    adv = pd.DataFrame(
+        {
+            "gameId": [f"00223000{i:02d}" for i in range(n)],
+            "personId": [f"p{i % 4 + 1}" for i in range(n)],
+            "teamId": ["t1"] * (n // 2) + ["t2"] * (n // 2),
+            "offensiveRating": [105.0] * n,
+            "usagePercentage": [0.25] * n,
+            "trueShootingPercentage": [0.55] * n,
+            "effectiveFieldGoalPercentage": [0.50] * n,
+            "assistToTurnover": [2.0] * n,
+        }
+    )
+    players = pd.DataFrame(
+        {
+            "person_id": ["p1", "p2", "p3", "p4"],
+            "position": ["G", "G", "F", "C"],
+        }
+    )
+    return box, adv, players
 
 
 class TestUnifiedTraining(unittest.TestCase):
     """Test unified training for both points and fantasy_points targets."""
-    
+
     def setUp(self):
-        """Create temporary directory for test models."""
         self.temp_dir = tempfile.TemporaryDirectory()
-    
+        # persist_model writes metrics CSV to databases/ — redirect cwd to temp dir
+        self.databases_dir = os.path.join(self.temp_dir.name, "databases")
+        os.makedirs(self.databases_dir, exist_ok=True)
+        self._orig_dir = os.getcwd()
+        os.chdir(self.temp_dir.name)
+
     def tearDown(self):
-        """Clean up temporary directory."""
+        os.chdir(self._orig_dir)
         self.temp_dir.cleanup()
-    
+
+    def _run_trainer(self, target: str):
+        box, adv, players = _make_mock_data()
+        model_path = os.path.join(self.temp_dir.name, f"{target}_model.pkl")
+        trainer = UnifiedModelTrainer(
+            target=target, model_path=model_path, save_mode="local"
+        )
+
+        def side_effect(filename, mode):
+            if filename == BoxscoreFileName:
+                return box
+            elif filename == AdvancedBoxscoreFileName:
+                return adv
+            elif filename == PlayersFileName:
+                return players
+            return pd.DataFrame()
+
+        with patch("common.training_helpers.load_data", side_effect=side_effect):
+            trainer.run(tune_params=False)
+
+        return trainer, model_path
+
     def test_points_target_training(self):
         """Test training with points target."""
-        print("\n🏀 Testing points prediction training...")
-        
-        model_path = os.path.join(self.temp_dir.name, "points_model.pkl")
-        trainer = UnifiedModelTrainer(
-            target="points",
-            model_path=model_path,
-            save_mode="local"
-        )
-        
-        # Run without tuning for speed
-        trainer.run(tune_params=False)
-        
-        # Verify model was saved
+        trainer, model_path = self._run_trainer("points")
         self.assertTrue(os.path.exists(model_path))
         self.assertTrue(len(trainer.feature_cols) > 0)
-        
-        print(f"✅ Points model trained with {len(trainer.feature_cols)} features")
-    
+
     def test_fantasy_target_training(self):
         """Test training with fantasy_points target."""
-        print("\n⭐ Testing fantasy points prediction training...")
-        
-        model_path = os.path.join(self.temp_dir.name, "fantasy_model.pkl")
-        trainer = UnifiedModelTrainer(
-            target="fantasy_points",
-            model_path=model_path,
-            save_mode="local"
-        )
-        
-        # Run without tuning for speed
-        trainer.run(tune_params=False)
-        
-        # Verify model was saved
+        trainer, model_path = self._run_trainer("fantasy_points")
         self.assertTrue(os.path.exists(model_path))
         self.assertTrue(len(trainer.feature_cols) > 0)
-        
-        print(f"✅ Fantasy model trained with {len(trainer.feature_cols)} features")
-    
+
     def test_invalid_target_raises_error(self):
         """Test that invalid target raises ValueError."""
-        print("\n❌ Testing invalid target...")
-        
         with self.assertRaises(ValueError):
             UnifiedModelTrainer(
                 target="invalid_target",
                 model_path="dummy.pkl",
-                save_mode="local"
+                save_mode="local",
             )
-        
-        print("✅ Invalid target correctly rejected")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- Add full player availability / injury report subsystem (`InjuryReportCollector`, `InjuryNormalizer`, `AvailabilityTableBuilder`) with 82 unit tests
- Integrate availability into `UnifiedPredictor`: only `Out` players excluded from predictions; `Doubtful`/`Questionable` receive predictions with a confidence score
- Confidence formula: `play_probability × stability × sample_conf` stored directly in `nba_predictions_df.csv`
- Add Jenkins `Unit Tests` stage using a venv to bypass PEP 668; fix insecure credential interpolation in `Initialize & Auth`; deploy & smoke test stages now trigger on `feature/*` branches
- Fix `run_all.sh`: add `get_injury_report` and `compute_availability` steps, fix wrong `-s` flag, remove duplicate DATE block
- Post-review fixes: `player_name` docstring corrected, `fillna(0)` removed from volatility rows (NaN now propagates correctly), `run()` return type changed to `None`

## Commits

| Hash | Description |
|---|---|
| `4c55e47` | [C020] Add player availability and injury report subsystem |
| `23e82d4` | [C021] Add test suite and CI readiness |
| `38a0957` | [C022] Add Jenkins CI pipeline |
| `9a6631b` | [C023] Fix run_all.sh and post-review fixes |

## Test results

- Local: **121 passed, 0 failed**
- Jenkins CI: **120 passed, 1 skipped** (integration test skipped — no real CSVs on CI, runs locally)

## Pipeline behaviour after merge to `dev`

Deploy & Create Job and Smoke Test stages will run, updating the `nba-training-develop` Cloud Run job.