### PR TITLE
 Overhaul fantasy_points model: quantile regression, encoder fix & pipeline fixes

### DIFF
--- a/common/feature_engineering.py
+++ b/common/feature_engineering.py
@@ -4,7 +4,6 @@ import datetime
 from typing import List, Dict, Tuple, Any
 from numpy.typing import NDArray
 from sklearn.preprocessing import OneHotEncoder
-from scipy.sparse import spmatrix
 from common.utils import parse_minutes
 
 

--- a/common/feature_engineering.py
+++ b/common/feature_engineering.py
@@ -2,7 +2,9 @@ import pandas as pd
 import numpy as np
 import datetime
 from typing import List, Dict, Tuple, Any
+from numpy.typing import NDArray
 from sklearn.preprocessing import OneHotEncoder
+from scipy.sparse import spmatrix
 from common.utils import parse_minutes
 
 
@@ -141,9 +143,8 @@ def create_historical_features(
     df_avg = (
         df_hist.groupby(
             ["position_group", "opponent", "game_date", "season"], as_index=False
-        )[target_col]
-        .mean()
-        .rename(columns={target_col: "avg_target"})
+        )
+        .agg(avg_target=(target_col, "mean"))
     )
 
     # sort chronologically per group (oldest -> newest)
@@ -200,16 +201,20 @@ def normalize_features(df: pd.DataFrame, key_stats: Dict[str, str]) -> pd.DataFr
     Returns:
         pd.DataFrame: The DataFrame with normalized features added.
     """
-    for stat in key_stats:
-        if stat in df.columns:
-            per36 = f"{stat}_per36"
-            df[per36] = df[stat] / df["minutes"] * 36
 
-    # And per-possession metrics
-    for stat in key_stats:
+    raw_stats = {k for k, v in key_stats.items() if "raw" in v.lower()}
+    eng_stats = {k for k, v in key_stats.items() if "engineering" in v.lower()}
+
+    for stat in raw_stats:
         if stat in df.columns:
-            ppp = f"{stat}_per_poss"
-            df[ppp] = df[stat] / df["possessions"]
+            df[f"{stat}_per36"]    = df[stat] / df["minutes"] * 36
+            df[f"{stat}_per_poss"] = df[stat] / df["possessions"]
+
+    # Engineering stats: expose raw value under both names — no minutes distortion
+    for stat in eng_stats:
+        if stat in df.columns:
+            df[f"{stat}_per36"]    = df[stat]
+            df[f"{stat}_per_poss"] = df[stat]
 
     return df
 
@@ -269,14 +274,17 @@ def compute_rolling_stats(
 
 
 def encode_categorical_features(
-    df: pd.DataFrame, categorical_cols: List[str]
-) -> Tuple[pd.DataFrame, List[str]]:
+    df: pd.DataFrame, 
+    categorical_cols: List[str],
+    encoder: OneHotEncoder | None = None
+) -> Tuple[pd.DataFrame, List[str], OneHotEncoder]:
     """
     Encode categorical features using one-hot encoding.
 
     Args:
         df (pd.DataFrame): input DataFrame
         categorical_cols (List[str]): list of categorical columns to encode
+        encoder (OneHotEncoder, optional): Pre-fitted OneHotEncoder. If None, a new one will be fitted.
 
     Returns:
         Tuple[pd.DataFrame, List[str], OneHotEncoder]:
@@ -284,9 +292,12 @@ def encode_categorical_features(
             - List of new feature names
             - Fitted encoder
     """
-    # encode categorical features
-    encoder: OneHotEncoder = OneHotEncoder(sparse_output=False, handle_unknown="ignore")
-    encoded_categorical: np.ndarray = encoder.fit_transform(df[categorical_cols])
+    if encoder is None:
+        # encode categorical features
+        encoder = OneHotEncoder(sparse_output=False, handle_unknown="ignore")
+        encoded_categorical: NDArray[Any] = encoder.fit_transform(df[categorical_cols])  # type: ignore
+    else:
+        encoded_categorical: NDArray[Any] = encoder.transform(df[categorical_cols])  # type: ignore
 
     feature_names: Any = encoder.get_feature_names_out(categorical_cols).tolist()
 
@@ -299,7 +310,7 @@ def encode_categorical_features(
         axis=1,
     )
 
-    return final_df, feature_names
+    return final_df, feature_names, encoder
 
 
 def get_feature_cols(
@@ -319,21 +330,26 @@ def get_feature_cols(
 
     # Separate raw stats (get rolling) vs engineering stats (get per36/per_poss only)
     raw_stats = [k for k, v in key_stats.items() if "raw" in v.lower()]
+    raw_stats_no_poss = [k for k in raw_stats if k != "possessions"]
     engineering_stats = [k for k, v in key_stats.items() if "engineering" in v.lower()]
 
     # 1) Add rolling features GROUPED BY WINDOW (matching notebook)
     for window in rolling_periods:
         # First add all _per36_rolling_X for this window
-        for stat in raw_stats:
+        for stat in raw_stats_no_poss:
             feature_cols.append(f"{stat}_per36_rolling_{window}")
 
         # Then add all _per_poss_rolling_X for this window
-        for stat in raw_stats:
+        for stat in raw_stats_no_poss:
             feature_cols.append(f"{stat}_per_poss_rolling_{window}")
 
         # Then add all raw rolling stats (e.g. minutes_rolling_5)
         for stat in raw_stats:
             feature_cols.append(f"{stat}_rolling_{window}")
+        # possessions_per36 rolling — only when possessions is in key_stats
+        # (points model does not include it, fantasy model does)
+        if "possessions" in raw_stats:
+            feature_cols.append(f"possessions_per36_rolling_{window}")
 
     # 2) Add historical averages (engineering stats) - per36 first, then per_poss
     for stat in engineering_stats:

--- a/common/model_utils.py
+++ b/common/model_utils.py
@@ -247,9 +247,12 @@ def evaluate_model(model: LGBMRegressor,
     logger.info(f"  Train → R²={train_r2:.4f}, RMSE={train_rmse:.4f}")
     logger.info(f"  Overfit Gap: {metrics['overfitting_gap']:.4f}")
 
-    # Pinball loss — the correct metric for quantile models.
-    # For regression models this is None (MAE/RMSE remain the primary metrics).
-    alpha = getattr(model, 'alpha', None)
+    # Pinball loss — only meaningful for quantile models.
+    # LGBMRegressor always exposes an `alpha` attribute (default 0.9) even for
+    # non-quantile objectives, so we guard on objective first to avoid computing
+    # misleading pinball metrics for standard regression models.
+    params = model.get_params() if hasattr(model, 'get_params') else {}
+    alpha = params.get('alpha') if params.get('objective') == 'quantile' else None
     if alpha is not None:
         def _pinball(y_true: Union[pd.Series, np.ndarray],
                      y_pred: Union[pd.Series, np.ndarray]) -> float:

--- a/common/model_utils.py
+++ b/common/model_utils.py
@@ -4,13 +4,15 @@ import numpy as np
 import joblib
 import os
 import logging
-from typing import Dict, List, Any, Tuple, Optional
+from typing import Dict, List, Any, Tuple, Optional, Union
 from datetime import datetime
 from sklearn.metrics import r2_score, mean_squared_error, mean_absolute_error
 from sklearn.model_selection import RandomizedSearchCV, TimeSeriesSplit
 from lightgbm import LGBMRegressor
 from google.cloud import storage
 import tempfile
+
+from sklearn.preprocessing import OneHotEncoder
 
 from common.io_utils import _parse_gcs_uri
 
@@ -60,7 +62,7 @@ def find_best_split(df: pd.DataFrame, target: str,
         model = LGBMRegressor(objective='regression', n_estimators=200, verbose=-1)
         model.fit(X_tr, y_tr)
         
-        y_pred = model.predict(X_te)
+        y_pred = np.asarray(model.predict(X_te)).ravel()
         rmse = np.sqrt(mean_squared_error(y_te, y_pred))
         r2 = r2_score(y_te, y_pred)
         
@@ -82,54 +84,89 @@ def find_best_split(df: pd.DataFrame, target: str,
     }
 
 def tune_hyperparameters(X_train: pd.DataFrame, y_train: pd.Series,
-                         n_iter: int = 20, cv_splits: int = 3) -> Dict[str, Any]:
+                         n_iter: int = 20, cv_splits: int = 3,
+                         alpha: Optional[float] = None) -> Dict[str, Any]:
     """
     Tune LightGBM hyperparameters using RandomizedSearchCV with time-series CV.
-    
+
     Args:
         X_train: training features
         y_train: training target
         n_iter: number of random search iterations
         cv_splits: number of time-series cross-validation splits
-        
+        alpha: quantile level (e.g. 0.75). When provided the base estimator uses
+               objective='quantile' and tuning is scored with pinball loss.
+               When None, objective='regression' and RMSE scoring are used.
+
     Returns:
-        dict with best hyperparameters
+        dict with best hyperparameters (objective/alpha are NOT included —
+        they are fixed constants, not search dimensions)
     """
     logger.info(f"🎯 Tuning hyperparameters ({n_iter} iterations, {cv_splits}-fold TimeSeriesCV)...")
-    
-    param_distributions = {
-        'n_estimators': [ 2000, 2200, 2500],
-        'learning_rate': [ 0.003, 0.004, 0.005],
-        'max_depth': [8, 9, 12],
-        'num_leaves': [80, 90, 100],
-        'min_child_samples': [ 40, 50],
-        'subsample': [ 0.8, 1.0],
-        'colsample_bytree': [0.6],
-        'reg_alpha': [ 0.8, 1.0],
-        'reg_lambda': [ 0.8, 1.0]
-    }
-    
+
+    if alpha is not None:
+        # Quantile regression — piecewise linear loss, needs faster/shallower tuning
+        param_distributions = {
+            'n_estimators':       [400, 600, 800, 1000, 1200],
+            'learning_rate':      [0.01, 0.02, 0.03, 0.05],
+            'max_depth':          [5, 6, 7, 8],
+            'num_leaves':         [31, 40, 50, 63],
+            'min_child_samples':  [30, 40, 50],
+            'subsample':          [0.7, 0.8, 0.9],
+            'colsample_bytree':   [0.5, 0.6, 0.7],
+            'reg_alpha':          [0.1, 0.5, 1.0],
+            'reg_lambda':         [0.5, 1.0, 2.0],
+        }
+    else:
+        # MSE regression — smooth loss tolerates slower/deeper tuning
+        param_distributions = {
+            'n_estimators':       [800, 1200, 1600, 2000],
+            'learning_rate':      [0.005, 0.01, 0.02, 0.05],
+            'max_depth':          [6, 7, 8, 9],
+            'num_leaves':         [50, 63, 80, 100],
+            'min_child_samples':  [30, 40, 50],
+            'subsample':          [0.7, 0.8, 1.0],
+            'colsample_bytree':   [0.6, 0.7],
+            'reg_alpha':          [0.0, 0.5, 1.0],
+            'reg_lambda':         [0.5, 1.0],
+        }
+
+    # Base estimator: fix objective/alpha so the tuner only searches the grid above.
+    # Typed as Any because LightGBM's type stubs do not expose BaseEstimator to Pylance.
+    lgbm: Any
+    if alpha is not None:
+        lgbm = LGBMRegressor(objective='quantile', alpha=alpha, verbose=-1, random_state=42)
+        # Pinball loss is the correct scoring metric for quantile models
+        def _pinball(y_true, y_pred):
+            e = np.asarray(y_true) - np.asarray(y_pred)
+            return float(np.where(e >= 0, alpha * e, (alpha - 1) * e).mean())
+        from sklearn.metrics import make_scorer
+        scoring = make_scorer(_pinball, greater_is_better=False)
+        logger.info(f"  Using quantile objective (α={alpha}) with pinball scoring")
+    else:
+        lgbm = LGBMRegressor(objective='regression', verbose=-1, random_state=42)
+        scoring = 'neg_root_mean_squared_error'
+        logger.info("  Using regression objective with RMSE scoring")
+
     # Time-series aware cross-validation
     tscv = TimeSeriesSplit(n_splits=cv_splits)
-
-    lgbm = LGBMRegressor(objective='regression', verbose=-1, random_state=42)
 
     random_search = RandomizedSearchCV(
         estimator=lgbm,
         param_distributions=param_distributions,
         n_iter=n_iter,
         cv=tscv,
-        scoring='neg_root_mean_squared_error',
+        scoring=scoring,
         n_jobs=-1,
         random_state=42,
-        verbose=1
+        verbose=1,
     )
-    
+
     random_search.fit(X_train, y_train)
 
-    logger.info(f"✅ Best CV R²: {-random_search.best_score_:.4f}")
+    logger.info(f"✅ Best CV score: {-random_search.best_score_:.4f}")
     logger.info(f"📋 Best params: {random_search.best_params_}")
-    
+
     return random_search.best_params_
 
 def train_model(X_train: pd.DataFrame, y_train: pd.Series,
@@ -147,7 +184,11 @@ def train_model(X_train: pd.DataFrame, y_train: pd.Series,
     """
     logger.info(f"🚀 Training final model with best params...")
     
-    model = LGBMRegressor(**best_params, objective='regression', verbose=-1)
+    # objective and verbose are carried by best_params when present (e.g. quantile);
+    # only inject defaults when the caller did not supply them.
+    params = {'objective': 'regression', 'verbose': -1}
+    params.update(best_params)
+    model = LGBMRegressor(**params)
     model.fit(X_train, y_train)
     
     # Log feature importance
@@ -181,13 +222,13 @@ def evaluate_model(model: LGBMRegressor,
     logger.info(f"📊 Evaluating model performance...")
     
     # Test set predictions
-    y_pred_test = model.predict(X_test)
+    y_pred_test = np.asarray(model.predict(X_test)).ravel()
     test_r2 = r2_score(y_test, y_pred_test)
     test_rmse = np.sqrt(mean_squared_error(y_test, y_pred_test))
     test_mae = mean_absolute_error(y_test, y_pred_test)
     
     # Train set predictions (overfitting check)
-    y_pred_train = model.predict(X_train)
+    y_pred_train = np.asarray(model.predict(X_train)).ravel()
     train_r2 = r2_score(y_train, y_pred_train)
     train_rmse = np.sqrt(mean_squared_error(y_train, y_pred_train))
     
@@ -199,13 +240,30 @@ def evaluate_model(model: LGBMRegressor,
         'train_rmse': train_rmse,
         'test_samples': len(X_test),
         'train_samples': len(X_train),
-        'overfitting_gap': train_r2 - test_r2
+        'overfitting_gap': train_r2 - test_r2,
     }
-    
+
     logger.info(f"  Test  → R²={test_r2:.4f}, RMSE={test_rmse:.4f}, MAE={test_mae:.4f}")
     logger.info(f"  Train → R²={train_r2:.4f}, RMSE={train_rmse:.4f}")
     logger.info(f"  Overfit Gap: {metrics['overfitting_gap']:.4f}")
-    
+
+    # Pinball loss — the correct metric for quantile models.
+    # For regression models this is None (MAE/RMSE remain the primary metrics).
+    alpha = getattr(model, 'alpha', None)
+    if alpha is not None:
+        def _pinball(y_true: Union[pd.Series, np.ndarray],
+                     y_pred: Union[pd.Series, np.ndarray]) -> float:
+            e = np.asarray(y_true) - np.asarray(y_pred)
+            return float(np.where(e >= 0, alpha * e, (alpha - 1) * e).mean())
+
+        metrics['test_pinball']  = round(_pinball(y_test,  y_pred_test),  4)
+        metrics['train_pinball'] = round(_pinball(y_train, y_pred_train), 4)
+        logger.info(f"  Pinball(α={alpha}) → test={metrics['test_pinball']:.4f}, "
+                    f"train={metrics['train_pinball']:.4f}")
+    else:
+        metrics['test_pinball']  = None
+        metrics['train_pinball'] = None
+
     return metrics
 
 def save_model_artifact(model: Any, metrics: Dict[str, Any], 
@@ -215,7 +273,8 @@ def save_model_artifact(model: Any, metrics: Dict[str, Any],
                         categorical_cols: List[str],
                         filepath: str,
                         save_mode: str = "local",
-                        scaler: Any = None) -> None:
+                        scaler: Any = None, 
+                        encoder: OneHotEncoder | None = None) -> None:
     """
     Save trained model, scaler, feature columns, and metrics to disk or GCS.
     
@@ -229,6 +288,7 @@ def save_model_artifact(model: Any, metrics: Dict[str, Any],
         filepath: path where to save the model artifact
         save_mode: save mode ('local' or 'bq')
         scaler: optional scaler object
+        encoder: optional OneHotEncoder object
     """
     # Define full filepath
     full_path = os.path.join(filepath, f"{target}_model.pkl")
@@ -237,6 +297,7 @@ def save_model_artifact(model: Any, metrics: Dict[str, Any],
     # Package everything needed for prediction
     artifact = {
         'model': model,
+        'encoder': encoder,
         'scaler': scaler,
         'feature_cols': feature_cols,
         'metrics': metrics,
@@ -304,14 +365,14 @@ def load_model_artifact(model_path: str, target: str, mode: str) -> Any:
     else:
         raise ValueError(f"Invalid mode: {mode}. Must be 'local' or 'bq'")
     
-    # Extract model from artifact dictionary
-    if isinstance(artifact, dict):
-        model = artifact.get('model')
-        if model is None:
-            raise ValueError(f"Model artifact missing 'model' key. Found keys: {list(artifact.keys())}")
-        logger.info(f"✅ Model loaded successfully from {model_path}")
-        return model
-    else:
-        # Artifact is already a model object
-        logger.info(f"✅ Model loaded successfully from {model_path}")
-        return artifact
+    # Normalise legacy artifacts (bare model objects saved without a dict wrapper)
+    if not isinstance(artifact, dict):
+        artifact = {'model': artifact}
+
+    if artifact.get('model') is None:
+        raise ValueError(
+            f"Artifact missing 'model' key. Found keys: {list(artifact.keys())}"
+        )
+
+    logger.info(f"✅ Artifact loaded successfully from {model_path}")
+    return artifact

--- a/common/training_helpers.py
+++ b/common/training_helpers.py
@@ -3,7 +3,7 @@
 import logging
 import pandas as pd
 import numpy as np
-from typing import Dict, List, Tuple, Any
+from typing import Dict, List, Tuple, Any, Optional
 
 from common.io_utils import BoxscoreFileName, AdvancedBoxscoreFileName, PlayersFileName, MetricsFileName, load_data, save_database
 from common.feature_engineering import (
@@ -48,7 +48,7 @@ def transform_data(
     categorical_cols: List[str],
     rolling_windows: List[int],
     target_computer_fn=None
-) -> Tuple[pd.DataFrame, List[str], List[str]]:
+) -> Tuple[pd.DataFrame, List[str], List[str], Any]:
     """
     Transform raw data into ML-ready features.
     
@@ -61,7 +61,7 @@ def transform_data(
         target_computer_fn: Optional function to compute custom target
         
     Returns:
-        Tuple of (transformed_df, feature_columns, encoded_columns)
+        Tuple of (transformed_df, feature_columns, encoded_columns, encoder)
     """
     logger.info("Transforming data...")
     
@@ -87,7 +87,7 @@ def transform_data(
     
     # 4. Encode Categoricals
     logger.info("Encoding categorical features...")
-    df, encoded_cols = encode_categorical_features(df, categorical_cols)
+    df, encoded_cols, encoder = encode_categorical_features(df, categorical_cols)
     
     # 5. Define Feature Columns
     feature_cols = get_feature_cols(key_stats, rolling_periods=rolling_windows)
@@ -99,7 +99,7 @@ def transform_data(
     feature_cols.extend(encoded_cols)
     logger.info(f"Total features: {len(feature_cols)}")
     
-    return df, feature_cols, encoded_cols
+    return df, feature_cols, encoded_cols, encoder 
 
 
 def split_train_test(
@@ -146,7 +146,7 @@ def train_and_evaluate(
     y_test: pd.Series,
     tune_params: bool = True,
     n_iter: int = 20,
-    default_params: Dict[str, Any] = None
+    default_params: Optional[Dict[str, Any]] = None
 ) -> Tuple[Any, Dict[str, Any]]:
     """
     Train model with optional hyperparameter tuning.
@@ -167,11 +167,27 @@ def train_and_evaluate(
     
     # Hyperparameter tuning or use defaults
     if tune_params:
-        best_params = tune_hyperparameters(X_train, y_train, n_iter=n_iter)
+        # Forward alpha from default_params so the tuner uses the correct
+        # objective (quantile vs regression) and scoring (pinball vs RMSE).
+        alpha = (default_params or {}).get('alpha', None)
+        best_params = tune_hyperparameters(X_train, y_train, n_iter=n_iter, alpha=alpha)
+        # Carry fixed params (objective, alpha) that are not part of the search space.
+        # Using `default_params and key in default_params` lets Pylance narrow the type
+        # to Dict[str, Any] inside the branch, avoiding the Optional subscript error.
+        for key in ('objective', 'alpha'):
+            if default_params and key in default_params:
+                best_params.setdefault(key, default_params[key])
     else:
-        best_params = default_params 
+        best_params = default_params
         logger.info("Using provided hyperparameters (tune_params=False)")
-    
+
+    # Guard: best_params must not be None before training.
+    # This can only happen if tune_params=False and default_params was not provided.
+    if best_params is None:
+        raise ValueError(
+            "No hyperparameters available: set tune_params=True or provide default_params."
+        )
+
     # Train final model
     model = train_model(X_train, y_train, best_params)
     
@@ -190,7 +206,8 @@ def persist_model(
     key_stats: Dict[str, str],
     categorical_cols: List[str],
     model_path: str,
-    save_mode: str = "local"
+    save_mode: str = "local", 
+    encoder: Any = None
 ) -> None:
     """
     Save trained model and metadata.
@@ -204,6 +221,7 @@ def persist_model(
         categorical_cols: List of categorical columns
         model_path: Path to save model
         save_mode: Save mode ('local' or 'bq')
+        encoder: Fitted encoder object (optional)
     """
     logger.info("Persisting model artifact...")
     save_model_artifact(
@@ -214,7 +232,8 @@ def persist_model(
         key_stats=key_stats,
         categorical_cols=categorical_cols,
         filepath=model_path,
-        save_mode=save_mode
+        save_mode=save_mode,
+        encoder=encoder
     )
     logger.info("Model saved successfully!")
     

--- a/ml_dev/notebooks/fantasy_points_eda.ipynb
+++ b/ml_dev/notebooks/fantasy_points_eda.ipynb
@@ -540,6 +540,182 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62e506f4",
+   "metadata": {},
+   "source": "## 5. Diagnose — Engineering Features Incorrectly Normalised\n\n**Bug:** `normalize_features()` iterates over **all** `key_stats`, including the three opponent-defensive\naggregates (`avg_fantasy_points_opp_position_last_10/20/all`).\nThose are team-level aggregates and should never be divided by an individual player's minutes.\n\n```python\n# common/feature_engineering.py  (lines 203-214)\nfor stat in key_stats:                        # ← includes engineering stats\n    per36 = f\"{stat}_per36\"\n    df[per36] = df[stat] / df[\"minutes\"] * 36  # ← nonsense for aggregates\n```\n\nResult: `avg_fp_opp_pos_last_10_per36 = avg_fp_opp_pos_last_10 / player_minutes * 36`\nA player who plays 36 min vs 12 min will have *the exact same defensive quality feature\nlook 3× different* — purely based on his playing time, corrupting one of the most informative signals."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "afc2f2af",
+   "metadata": {},
+   "outputs": [],
+   "source": "# ── Reproduce the bug ──────────────────────────────────────────────────────\nimport sys, os\nsys.path.insert(0, os.path.abspath(os.path.join('..', '..')))\n\nimport pandas as pd\nimport numpy as np\nimport warnings\nwarnings.filterwarnings('ignore')\n\nfrom common.feature_engineering import (\n    merge_data, preprocess_data, create_historical_features,\n    normalize_features, compute_rolling_stats, get_feature_cols\n)\nfrom src.targets.fantasy_points import compute_fantasy_points\nfrom common.constants import key_stats_fantasy\n\n# Load data\nbox     = pd.read_csv('../../databases/nba_boxscore_basic.csv', low_memory=False)\nadv     = pd.read_csv('../../databases/nba_boxscore_advanced.csv', low_memory=False)\nplayers = pd.read_csv('../../databases/nba_players_df.csv')\n\ndf = merge_data(box, adv, players)\ndf = preprocess_data(df)\ndf = compute_fantasy_points(df)\ndf = create_historical_features(df, target_col='fantasy_points')\n\n# Apply current (buggy) normalisation\ndf_buggy = normalize_features(df.copy(), key_stats_fantasy)\n\neng_stat  = 'avg_fantasy_points_opp_position_last_10'\ncol_buggy = f'{eng_stat}_per36'\n\nprint(\"Engineering stat — raw values (sample):\")\nprint(df_buggy[eng_stat].describe())\nprint(f\"\\n{col_buggy} — after /minutes*36 (should be SAME value for same matchup, not player-dependent):\")\nprint(df_buggy[col_buggy].describe())\ncorr = df_buggy['minutes'].corr(df_buggy[col_buggy])\nprint(f\"\\nCorrelation with minutes: {corr:.3f}\")\nprint(\"→ High minutes correlation means this feature encodes playing time, NOT defensive quality!\")\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "960a45f7",
+   "metadata": {},
+   "outputs": [],
+   "source": "# ── The fix: normalise only raw stats ──────────────────────────────────────\ndef normalize_features_fixed(df: pd.DataFrame, key_stats: dict) -> pd.DataFrame:\n    \"\"\"\n    Fixed: only RAW stats get per36/per_poss treatment.\n    Engineering (opponent-defensive) stats are kept as-is.\n    \"\"\"\n    raw_stats = {k for k, v in key_stats.items() if 'raw'         in v.lower()}\n    eng_stats = {k for k, v in key_stats.items() if 'engineering' in v.lower()}\n\n    for stat in raw_stats:\n        if stat in df.columns:\n            df[f'{stat}_per36']    = df[stat] / df['minutes'] * 36\n            df[f'{stat}_per_poss'] = df[stat] / df['possessions']\n\n    # Engineering stats: expose them directly under the _per36/_per_poss names\n    # so get_feature_cols() references still resolve, but no minutes distortion.\n    for stat in eng_stats:\n        if stat in df.columns:\n            df[f'{stat}_per36']    = df[stat]\n            df[f'{stat}_per_poss'] = df[stat]\n\n    return df\n\ndf_fixed_norm = normalize_features_fixed(df.copy(), key_stats_fantasy)\n\ncorr_fixed = df_fixed_norm['minutes'].corr(df_fixed_norm[f'{eng_stat}_per36'])\nprint(f\"Fixed — correlation of {eng_stat}_per36 with minutes: {corr_fixed:.3f}\")\nprint(\"(Should be low/near-zero — it now encodes matchup quality, not playing time)\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c322db9",
+   "metadata": {},
+   "source": "## 6. Diagnose — `possessions_per_poss` is a Constant Feature (Always 1.0)\n\n**Bug:** `possessions` is listed in `key_stats_fantasy` as a raw stat.\n`normalize_features` computes `possessions_per_poss = possessions / possessions = 1.0` for every row.\nAfter rolling, all `possessions_per_poss_rolling_{3,7,15,30}` features are also 1.0.\n\nThese 4 constant features consume feature-importance budget and add noise to the model."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "893c7e53",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Verify the constant-feature bug\ndf_check = normalize_features(df.copy(), key_stats_fantasy)\n\nposs_ppp = 'possessions_per_poss'\nif poss_ppp in df_check.columns:\n    unique_vals = df_check[poss_ppp].dropna().unique()\n    print(f'{poss_ppp} — unique values: {unique_vals[:8]}')\n    print(f'All 1.0? {(df_check[poss_ppp].dropna().round(6) == 1.0).all()}')\nelse:\n    print(f'{poss_ppp} column not present')\n\n# Confirm rolling features are also constant\ndf_rolled = compute_rolling_stats(df_check, key_stats_fantasy, windows=[3,7,15,30])\nrolling_cols = [c for c in df_rolled.columns if 'possessions_per_poss_rolling' in c]\nprint(f'\\nRolling possessions_per_poss cols: {rolling_cols}')\nfor col in rolling_cols:\n    all_one = (df_rolled[col].dropna().round(6) == 1.0).all()\n    print(f'  {col}: all 1.0 = {all_one}')\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f704616",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Check feature importance of those constant columns in the baseline model\nfrom lightgbm import LGBMRegressor\n\ndf_fi = compute_rolling_stats(\n    normalize_features(df.copy(), key_stats_fantasy),\n    key_stats_fantasy, windows=[3,7,15,30]\n).dropna(subset=['fantasy_points'])\n\nfeat_baseline = [f for f in get_feature_cols(key_stats_fantasy, rolling_periods=[3,7,15,30])\n                 if f in df_fi.columns]\nX_fi = df_fi[feat_baseline].replace([np.inf,-np.inf], np.nan).fillna(0)\ny_fi = df_fi['fantasy_points']\n\nm_fi = LGBMRegressor(n_estimators=200, verbose=-1, random_state=42)\nm_fi.fit(X_fi, y_fi)\n\nfi_df = pd.DataFrame({'feature': feat_baseline,\n                       'importance': m_fi.feature_importances_}).sort_values('importance')\nposs_fi = fi_df[fi_df['feature'].str.contains('possessions_per_poss')]\nprint(\"Feature importance for possessions_per_poss_rolling_* (expect ~0):\")\nprint(poss_fi.to_string(index=False))\n"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d033412",
+   "metadata": {},
+   "source": "## 7. Diagnose — Encoder Re-fit at Inference (Silent Misalignment Risk)\n\n**Problem:** `encode_categorical_features()` creates a brand-new `OneHotEncoder` and fits it\non the *current* historical data at every prediction run.\nAs new seasons accumulate, the column order shifts. The `reindex(fill_value=0)` rescue in\n`get_final_df` catches explicit mismatches but can silently zero-out valid season columns.\n\n**Fix:** Serialise the fitted encoder inside the model artifact. At inference, reuse it.\nOnly re-fit when re-training."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b5db57b",
+   "metadata": {},
+   "outputs": [],
+   "source": "from sklearn.preprocessing import OneHotEncoder\nfrom common.constants import categorical_cols_fantasy\n\n# ── Reproduce the drift ───────────────────────────────────────────────────\nseasons_train = df[df['season'] <= 2024].copy()\nseasons_all   = df.copy()\n\nenc_old = OneHotEncoder(sparse_output=False, handle_unknown='ignore')\nenc_old.fit(seasons_train[categorical_cols_fantasy])\n\nenc_new = OneHotEncoder(sparse_output=False, handle_unknown='ignore')\nenc_new.fit(seasons_all[categorical_cols_fantasy])\n\ncols_old = set(enc_old.get_feature_names_out(categorical_cols_fantasy))\ncols_new = set(enc_new.get_feature_names_out(categorical_cols_fantasy))\n\nprint(f\"Columns only in NEW encoder (seasons added after training): {cols_new - cols_old}\")\nprint(f\"Columns only in OLD encoder (seasons no longer in window):  {cols_old - cols_new}\")\nprint(f\"\\nModel trained on {len(cols_old)} encoded cols;\")\nprint(f\"inference feed has {len(cols_new)} encoded cols before reindex.\")\nprint(\"\\n→ Fix: save enc_old in the model pickle, reuse it at inference time.\")\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4fc04e77",
+   "metadata": {},
+   "outputs": [],
+   "source": "# ── Skeleton: encode_with_saved_encoder() ────────────────────────────────\ndef encode_with_saved_encoder(\n    df: pd.DataFrame,\n    categorical_cols: list,\n    encoder: OneHotEncoder = None\n):\n    \"\"\"\n    Training time : pass encoder=None  → fit, return encoder.\n    Inference time: pass saved encoder → transform only, no refit.\n    \"\"\"\n    if encoder is None:\n        encoder = OneHotEncoder(sparse_output=False, handle_unknown='ignore')\n        encoded = encoder.fit_transform(df[categorical_cols])\n    else:\n        encoded = encoder.transform(df[categorical_cols])\n\n    feature_names = encoder.get_feature_names_out(categorical_cols).tolist()\n    df = df.drop(categorical_cols, axis=1)\n    df = pd.concat(\n        [df, pd.DataFrame(encoded, columns=feature_names, index=df.index)], axis=1\n    )\n    return df, feature_names, encoder\n\n# Training\ndf_enc_train, enc_feat_names, saved_enc = encode_with_saved_encoder(\n    df[df['season'] <= 2024].copy(), categorical_cols_fantasy\n)\nprint(f\"Training encoder fitted → {len(enc_feat_names)} columns\")\n\n# Inference (reuse same encoder)\ndf_enc_infer, inf_feat_names, _ = encode_with_saved_encoder(\n    df[df['season'] > 2024].copy(), categorical_cols_fantasy, encoder=saved_enc\n)\nprint(f\"Inference (same encoder) → {len(inf_feat_names)} columns (handle_unknown=ignore for new seasons)\")\nprint(\"No column order surprise. New seasons get all-zero encoding automatically.\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b6ca834",
+   "metadata": {},
+   "source": "## 8. Fix — Quantile Regression to Escape the Prediction Ceiling\n\n**Root cause of the ~48 ceiling:** `objective='regression'` minimises MSE → predicts the\n*conditional mean*. Even Jokić's conditional mean is ~45–48.\n\nFor TTFL you pick 1 player per night — you want the player with the highest **upside**,\nnot the highest average.\n\n**Fix:** `objective='quantile', alpha=0.75` or `0.85` predicts the upper quartile/quintile.\nA player with a high 75th-percentile score is more likely to deliver a big night.\n\n| Model | Objective | What it predicts |\n|-------|-----------|------------------|\n| Baseline | `regression` (MSE) | Conditional mean |\n| Q75 | `quantile alpha=0.75` | 75th percentile |\n| Q85 | `quantile alpha=0.85` | 85th percentile |"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4158149",
+   "metadata": {},
+   "outputs": [],
+   "source": "from sklearn.metrics import mean_absolute_error, r2_score\nimport matplotlib.pyplot as plt\n\n# ── Time-based split ─────────────────────────────────────────────────────\ndf_model = normalize_features(df.copy(), key_stats_fantasy)\ndf_model = compute_rolling_stats(df_model, key_stats_fantasy, windows=[3,7,15,30])\ndf_model = df_model.dropna(subset=['fantasy_points']).sort_values('game_date')\n\nfeat_list    = get_feature_cols(key_stats_fantasy, rolling_periods=[3,7,15,30])\navail_feats  = [f for f in feat_list if f in df_model.columns]\n\nunique_dates = np.sort(df_model['game_date'].unique())\nsplit_date   = unique_dates[int(0.80 * len(unique_dates))]\n\ntrain = df_model[df_model['game_date'] <  split_date]\ntest  = df_model[df_model['game_date'] >= split_date]\n\nX_tr = train[avail_feats].replace([np.inf,-np.inf], np.nan).fillna(0)\ny_tr = train['fantasy_points']\nX_te = test[avail_feats].replace([np.inf,-np.inf],  np.nan).fillna(0)\ny_te = test['fantasy_points']\n\nprint(f\"Train: {len(X_tr):,} rows  |  Test: {len(X_te):,} rows  |  Split: {split_date}\")\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea1b25b6",
+   "metadata": {},
+   "outputs": [],
+   "source": "# ── Train 3 models ───────────────────────────────────────────────────────\nbase_params = dict(n_estimators=500, learning_rate=0.05, max_depth=7,\n                   num_leaves=63, subsample=0.8, colsample_bytree=0.7,\n                   verbose=-1, random_state=42)\n\nm_mean = LGBMRegressor(**base_params, objective='regression')\nm_q75  = LGBMRegressor(**base_params, objective='quantile', alpha=0.75)\nm_q85  = LGBMRegressor(**base_params, objective='quantile', alpha=0.85)\n\nfor m in (m_mean, m_q75, m_q85):\n    m.fit(X_tr, y_tr)\n\npred_mean = m_mean.predict(X_te)\npred_q75  = m_q75.predict(X_te)\npred_q85  = m_q85.predict(X_te)\n\nprint(\"── Prediction ceiling comparison ─────────────────────────────────\")\nprint(f\"  {'Model':<22} {'max':>6} {'p95':>6} {'p99':>6} {'MAE':>7}\")\nprint(f\"  {'-'*48}\")\nfor label, preds in [('Mean (current prod)', pred_mean),\n                      ('Quantile-75',        pred_q75),\n                      ('Quantile-85',        pred_q85)]:\n    print(f\"  {label:<22} {preds.max():>6.1f} {np.percentile(preds,95):>6.1f}\"\n          f\" {np.percentile(preds,99):>6.1f} {mean_absolute_error(y_te,preds):>7.2f}\")\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2762c407",
+   "metadata": {},
+   "outputs": [],
+   "source": "# ── Distribution: predicted vs actual ────────────────────────────────────\nfig, axes = plt.subplots(1, 3, figsize=(18, 5), sharey=False)\nbins = np.linspace(-10, 120, 50)\n\nfor ax, preds, title, color in zip(\n    axes,\n    [pred_mean, pred_q75, pred_q85],\n    ['MSE regression (current)', 'Quantile 0.75', 'Quantile 0.85'],\n    ['tomato', 'darkorange', '#2e7d32']\n):\n    ax.hist(y_te, bins=bins, alpha=0.45, label='Actual',    color='steelblue')\n    ax.hist(preds,   bins=bins, alpha=0.60, label='Predicted', color=color)\n    ax.set_title(title); ax.set_xlabel('TTFL Score'); ax.legend()\n\nplt.suptitle('Distribution — Actual vs Predicted TTFL (test set)', fontsize=14, fontweight='bold')\nplt.tight_layout()\nplt.show()\n\n# How many elite nights (≥60) did each model identify in top predictions?\nelite_actual = y_te >= 60\nprint(f\"\\nElite game nights in test set (actual ≥ 60): {elite_actual.sum()}\")\nfor label, preds in [('Mean  ', pred_mean), ('Q75   ', pred_q75), ('Q85   ', pred_q85)]:\n    top_n = np.argsort(preds)[::-1][:int(elite_actual.sum())]\n    hit_rate = elite_actual.values[top_n].mean()\n    print(f\"  {label}: hit-rate among top-N predictions = {hit_rate:.1%}\")\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dff3d772",
+   "metadata": {},
+   "outputs": [],
+   "source": "# ── Scatter: predicted vs actual (test set) ──────────────────────────────\nfig, axes = plt.subplots(1, 3, figsize=(18, 6))\nfor ax, preds, title, color in zip(\n    axes,\n    [pred_mean, pred_q75, pred_q85],\n    ['MSE regression (current)', 'Quantile 0.75', 'Quantile 0.85'],\n    ['tomato', 'darkorange', '#2e7d32']\n):\n    ax.scatter(preds, y_te.values, alpha=0.12, s=7, color=color)\n    lim = max(preds.max(), y_te.max()) + 5\n    ax.plot([0, lim], [0, lim], 'k--', lw=1, label='Perfect')\n    ax.set_xlim(0, lim); ax.set_ylim(0, lim)\n    ax.set_xlabel('Predicted'); ax.set_ylabel('Actual')\n    ax.set_title(title)\n    ax.text(0.05, 0.93, f'MAE = {mean_absolute_error(y_te, preds):.1f}',\n            transform=ax.transAxes, fontsize=10)\n\nplt.suptitle('Predicted vs Actual TTFL — test set', fontsize=14, fontweight='bold')\nplt.tight_layout()\nplt.show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54330ac2",
+   "metadata": {},
+   "source": "## 9. Full Pipeline — Baseline vs Fixed Model (All Changes Combined)\n\nCombining:\n1. Engineering stats not normalised by player minutes  \n2. `possessions_per_poss` constant feature excluded  \n3. Quantile-0.75 objective  \n4. Encoder reused (consistent fit on training window)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5c6df3e",
+   "metadata": {},
+   "outputs": [],
+   "source": "# ── Helper: fixed feature columns ───────────────────────────────────────\ndef get_feature_cols_fixed(key_stats: dict, rolling_periods: list) -> list:\n    \"\"\"\n    Fixed get_feature_cols:\n    - Raw stats only get per36/per_poss rolling treatment\n    - Engineering stats are included raw (the stat name itself, not per36/per_poss)\n    - possessions excluded from per_poss rolling\n    \"\"\"\n    raw_stats = [k for k, v in key_stats.items()\n                 if 'raw' in v.lower() and k != 'possessions']\n    eng_stats = [k for k, v in key_stats.items() if 'engineering' in v.lower()]\n\n    feature_cols = []\n    for window in rolling_periods:\n        for stat in raw_stats:\n            feature_cols.append(f'{stat}_per36_rolling_{window}')\n        for stat in raw_stats:\n            feature_cols.append(f'{stat}_per_poss_rolling_{window}')\n        for stat in raw_stats:\n            feature_cols.append(f'{stat}_rolling_{window}')\n    # possessions raw rolling (per36 only, no per_poss)\n    for window in rolling_periods:\n        feature_cols.append(f'possessions_per36_rolling_{window}')\n        feature_cols.append(f'possessions_rolling_{window}')\n    # Engineering stats: raw signal\n    for stat in eng_stats:\n        feature_cols.append(stat)\n    feature_cols.append('rest_days')\n    return feature_cols\n\n\n# ── BASELINE pipeline (current prod) ─────────────────────────────────────\ndf_b = normalize_features(df.copy(), key_stats_fantasy)\ndf_b = compute_rolling_stats(df_b, key_stats_fantasy, windows=[3,7,15,30])\ndf_b = df_b.dropna(subset=['fantasy_points']).sort_values('game_date')\n\nfeat_b    = [f for f in get_feature_cols(key_stats_fantasy, rolling_periods=[3,7,15,30])\n             if f in df_b.columns]\nsplit_d   = np.sort(df_b['game_date'].unique())[int(0.80 * df_b['game_date'].nunique())]\n\nX_tr_b = df_b[df_b['game_date'] <  split_d][feat_b].replace([np.inf,-np.inf], np.nan).fillna(0)\ny_tr_b = df_b[df_b['game_date'] <  split_d]['fantasy_points']\nX_te_b = df_b[df_b['game_date'] >= split_d][feat_b].replace([np.inf,-np.inf], np.nan).fillna(0)\ny_te_b = df_b[df_b['game_date'] >= split_d]['fantasy_points']\n\nm_base = LGBMRegressor(n_estimators=500, learning_rate=0.05, max_depth=7,\n                        verbose=-1, random_state=42, objective='regression')\nm_base.fit(X_tr_b, y_tr_b)\npred_base = m_base.predict(X_te_b)\n\n\n# ── FIXED pipeline ───────────────────────────────────────────────────────\ndf_f = normalize_features_fixed(df.copy(), key_stats_fantasy)\ndf_f = compute_rolling_stats(df_f, key_stats_fantasy, windows=[3,7,15,30])\ndf_f = df_f.dropna(subset=['fantasy_points']).sort_values('game_date')\n\nfeat_f  = [f for f in get_feature_cols_fixed(key_stats_fantasy, [3,7,15,30])\n           if f in df_f.columns]\n\nX_tr_f = df_f[df_f['game_date'] <  split_d][feat_f].replace([np.inf,-np.inf], np.nan).fillna(0)\ny_tr_f = df_f[df_f['game_date'] <  split_d]['fantasy_points']\nX_te_f = df_f[df_f['game_date'] >= split_d][feat_f].replace([np.inf,-np.inf], np.nan).fillna(0)\ny_te_f = df_f[df_f['game_date'] >= split_d]['fantasy_points']\n\nm_fix = LGBMRegressor(n_estimators=500, learning_rate=0.05, max_depth=7,\n                       num_leaves=63, subsample=0.8, colsample_bytree=0.7,\n                       verbose=-1, random_state=42,\n                       objective='quantile', alpha=0.75)\nm_fix.fit(X_tr_f, y_tr_f)\npred_fix = m_fix.predict(X_te_f)\n\n\n# ── Side-by-side metrics ─────────────────────────────────────────────────\nprint(\"═\" * 60)\nprint(f\"  {'Metric':<26} {'Baseline':>12} {'Fixed':>12}\")\nprint(\"─\" * 60)\nprint(f\"  {'MAE':<26} {mean_absolute_error(y_te_b, pred_base):>12.2f} {mean_absolute_error(y_te_f, pred_fix):>12.2f}\")\nprint(f\"  {'R²':<26} {r2_score(y_te_b, pred_base):>12.4f} {r2_score(y_te_f, pred_fix):>12.4f}\")\nprint(f\"  {'Pred max':<26} {pred_base.max():>12.1f} {pred_fix.max():>12.1f}\")\nprint(f\"  {'Pred p95':<26} {np.percentile(pred_base,95):>12.1f} {np.percentile(pred_fix,95):>12.1f}\")\nprint(f\"  {'Pred p99':<26} {np.percentile(pred_base,99):>12.1f} {np.percentile(pred_fix,99):>12.1f}\")\nprint(f\"  {'Features used':<26} {len(feat_b):>12} {len(feat_f):>12}\")\nprint(\"═\" * 60)\n"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e274a8f",
+   "metadata": {},
+   "source": "## 10. April 4, 2026 — Predicted vs Actual Visual Comparison\n\nReal-night results against production predictions.\n*Embiid (DNP despite Available status) is shown separately.*"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5dcd6e7",
+   "metadata": {},
+   "outputs": [],
+   "source": "import matplotlib.pyplot as plt\nimport matplotlib.patches as mpatches\nimport numpy as np\n\n# Ground truth\nactuals_apr4 = {\n    'Nikola Joki\\u0107': 73,\n    'Victor Wembanyama': 76,\n    'Joel Embiid': None,\n    'Bam Adebayo': 34,\n    'Tyrese Maxey': 25,\n    'Jalen Duren': 32,\n    'Julian Reese': 9,\n}\n\n# Production predictions\npreds_prod = {\n    'Nikola Joki\\u0107': 48.2,\n    'Victor Wembanyama': 41.2,\n    'Joel Embiid': 44.0,\n    'Bam Adebayo': 43.5,\n    'Tyrese Maxey': 42.8,\n    'Jalen Duren': 37.6,\n    'Julian Reese': 35.4,\n}\n\nplayers_chart = [p for p, v in actuals_apr4.items() if v is not None]\nactual_vals   = [actuals_apr4[p] for p in players_chart]\npred_vals     = [preds_prod[p]   for p in players_chart]\n\nx     = np.arange(len(players_chart))\nwidth = 0.38\n\nfig, ax = plt.subplots(figsize=(14, 6))\nax.bar(x - width/2, pred_vals,   width, label='Predicted (prod)', color='#2196F3', alpha=0.85)\nax.bar(x + width/2, actual_vals, width, label='Actual',           color='#4CAF50', alpha=0.85)\n\n# Annotate errors\nfor i, (p, a) in enumerate(zip(pred_vals, actual_vals)):\n    err = p - a\n    color = '#d32f2f' if abs(err) > 15 else '#f57c00' if abs(err) > 8 else '#388e3c'\n    ax.text(i, max(p, a) + 2, f'{err:+.0f}', ha='center', va='bottom',\n            fontsize=9, color=color, fontweight='bold')\n\n# Ceiling reference\nax.axhline(48.2, color='#2196F3', linestyle='--', linewidth=1.3, alpha=0.6,\n           label='Prod ceiling (~48)')\n\nax.set_xticks(x)\nax.set_xticklabels(players_chart, rotation=20, ha='right')\nax.set_ylabel('TTFL Fantasy Points')\nax.set_title(\n    'April 4, 2026 — Predicted vs Actual TTFL\\n'\n    '(numbers = prediction error; Embiid DNP excluded from bars)',\n    fontsize=13, fontweight='bold'\n)\nax.legend(loc='upper right')\nax.set_ylim(0, 90)\nax.text(0.01, 0.97,\n        'Joel Embiid: predicted 44.0 (Available) → DNP — last-minute scratch not captured',\n        transform=ax.transAxes, fontsize=8.5, color='#d32f2f', va='top')\nplt.tight_layout()\nplt.show()\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ba8ab95",
+   "metadata": {},
+   "outputs": [],
+   "source": "# ── Error summary table ──────────────────────────────────────────────────\nrows = []\nfor player in players_chart:\n    pred   = preds_prod[player]\n    actual = actuals_apr4[player]\n    err    = pred - actual\n    rows.append({\n        'Player':     player,\n        'Predicted':  pred,\n        'Actual':     actual,\n        'Error':      round(err, 1),\n        'Abs Error':  round(abs(err), 1),\n        'Direction':  'Under' if err < 0 else 'Over',\n        'Root cause': (\n            'Mean regression — elite ceiling' if err < -15 else\n            'Role inflation (teammate out)' if player == 'Julian Reese' else\n            'Mild overfit to recent form'\n        )\n    })\n\ncmp = pd.DataFrame(rows).sort_values('Abs Error', ascending=False)\nprint(cmp.to_string(index=False))\nprint(f\"\\nMean Absolute Error (Apr 4, prod model): {cmp['Abs Error'].mean():.1f} TTFL pts\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddd5cd61",
+   "metadata": {},
+   "source": "## 11. Diagnose — Role Inflation: Julian Reese (predicted 35.4, actual 9)\n\nReese received starter-level minutes while Anthony Davis was absent.\nThe model extrapolated those minutes forward but had no signal that Davis would be active again.\n\n**Trace:** look at Reese's minutes trend. A spike followed by a return to bench role\nis the classic pattern the model mistakes for a stable new baseline.\n\n**Fix candidates**\n- `star_teammate_is_out` binary feature (team's top-minutes player unavailable)\n- `minutes_rolling_trend` = minutes_rolling_3 - minutes_rolling_15 (detects temporary spikes)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b628b97",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Trace Reese's recent minutes\nfrom common.utils import parse_minutes\n\nreese_candidates = players[\n    players['player_last_name'].str.lower().str.contains('reese', na=False)\n]\nprint(\"Reese candidates in players table:\")\nprint(reese_candidates[['person_id', 'player_first_name', 'player_last_name']].to_string(index=False))\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a25fc468",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Replace with the person_id from above output\nREESE_ID = reese_candidates['person_id'].iloc[0]\n\nreese_games = box[box['personId'] == REESE_ID].copy()\nreese_games['game_date'] = pd.to_datetime(reese_games['game_date'])\nreese_games = reese_games.sort_values('game_date').tail(25)\n\nif reese_games['minutes'].dtype == object:\n    reese_games['minutes'] = reese_games['minutes'].apply(parse_minutes)\n\nfig, ax = plt.subplots(figsize=(13, 4))\nax.bar(range(len(reese_games)), reese_games['minutes'],\n       color='steelblue', alpha=0.8)\navg_min = reese_games['minutes'].mean()\nroll7   = reese_games['minutes'].rolling(7, min_periods=1).mean()\nax.plot(range(len(reese_games)), roll7, color='darkorange', lw=2, label='7-game rolling avg')\nax.axhline(avg_min, color='red', linestyle='--', lw=1.2,\n           label=f'Season avg = {avg_min:.1f} min')\nax.set_xticks(range(len(reese_games)))\nax.set_xticklabels([str(d.date()) for d in reese_games['game_date']],\n                    rotation=45, ha='right', fontsize=7)\nax.set_ylabel('Minutes')\nax.set_title('Julian Reese — Minutes per Game (last 25)')\nax.legend()\nplt.tight_layout()\nplt.show()\n\nprint(f\"Rolling 3-game avg:  {reese_games['minutes'].tail(3).mean():.1f} min\")\nprint(f\"Rolling 15-game avg: {reese_games['minutes'].tail(15).mean():.1f} min\")\nprint(\"→ If 3-game avg >> 15-game avg, the model sees a spike it mistakes for a new baseline.\")\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56178f2e",
+   "metadata": {},
+   "outputs": [],
+   "source": "# ── Prototype: minutes_rolling_trend feature ─────────────────────────────\ndf_trend = df.copy()\ndf_trend = df_trend.sort_values(['personId', 'game_date'])\n\n# minutes_rolling_trend > 0 → player getting MORE minutes recently (temp spike)\n# minutes_rolling_trend < 0 → player getting FEWER minutes (returning to bench)\ndf_trend['min_roll3']  = df_trend.groupby('personId')['minutes'].transform(\n    lambda x: x.shift(1).rolling(3, min_periods=1).mean())\ndf_trend['min_roll15'] = df_trend.groupby('personId')['minutes'].transform(\n    lambda x: x.shift(1).rolling(15, min_periods=1).mean())\ndf_trend['minutes_rolling_trend'] = df_trend['min_roll3'] - df_trend['min_roll15']\n\n# Correlation: when trend is positive (minutes spike), does actual fantasy_points follow?\ncorr_trend = df_trend['minutes_rolling_trend'].corr(df_trend['fantasy_points'])\nprint(f\"Correlation of minutes_rolling_trend with fantasy_points: {corr_trend:.3f}\")\nprint(\"(Should be moderate-positive; if model over-weights it, it inflates predictions\")\nprint(\" for players mid-spike — exactly the Reese scenario)\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71831f3a",
+   "metadata": {},
+   "source": "## 12. Summary — All Fixes & Deployment Checklist\n\n| # | Issue | File / Location | Fix | Expected Impact |\n|---|-------|----------------|-----|----------------|\n| 1 | Engineering stats normalised by player minutes | `feature_engineering.py:203` | Apply per36/per_poss only to raw stats | Better matchup signal → –2–3 pts MAE |\n| 2 | `possessions_per_poss` always 1.0 | `feature_engineering.py:208` | Skip possessions from per_poss norm | Remove 4 constant noise features |\n| 3 | Encoder re-fit every inference | `feature_engineering.py:288`, `model_utils.py:238` | Serialise encoder in pkl, reuse at inference | Eliminate silent column misalignment |\n| 4 | MSE objective → ~48 ceiling | `model_utils.py:116,150` | `objective='quantile', alpha=0.75` | Ceiling lifts to 60–70+, better top picks |\n| 5 | Role inflation (no teammate context) | new feature | `minutes_rolling_trend` feature + `star_teammate_is_out` | Prevent Reese-type blow-ups |\n| 6 | Availability stale (morning fetch only) | availability pipeline | Re-fetch at 5PM (game-day injury report) | Catch Embiid-type last-minute DNPs |\n\n### Deployment steps\n1. Update `normalize_features()` → separate raw vs engineering paths  \n2. Update `get_feature_cols()` → use engineering stats raw  \n3. Update `save_model_artifact()` + `load_model_artifact()` → include `encoder` key  \n4. Update `encode_categorical_features()` → accept optional pre-fitted encoder  \n5. Add `minutes_rolling_trend` to `key_stats_fantasy` (raw stat) in `constants.py`  \n6. Update `DEFAULT_PARAMS['fantasy_points']` in `train.py` → `objective='quantile', alpha=0.75`  \n7. Retrain model  \n8. Validate on April 4 scenario (Section 10 of this notebook) before merging to master"
   }
  ],
  "metadata": {

--- a/scripts/run_all.sh
+++ b/scripts/run_all.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 : "${SEASON_TYPE:=Regular Season}"      # default to Regular Season
 : "${SAVE_MODE:=local}"                    # default to local (bq for Cloud)
 : "${MODEL_PATH:=ml_dev/models}"            # default to local directory
-: "${TARGET:=points}"                      # default to points only
+: "${TARGETS:=points}"                      # default to points only
 : "${TUNE_HYPERPARAMETERS:=false}"         # default to no tuning
 
 # Optional proxy creds (exported if present)
@@ -74,7 +74,7 @@ log "✅ Finished compute_availability"
 
 log "➡️ Running train..."
 # Convert space-separated targets to individual arguments
-python main.py -p train -sm "$SAVE_MODE" -m "$MODEL_PATH" -t $TARGET --tune_params "$TUNE_HYPERPARAMETERS"
+python main.py -p train -sm "$SAVE_MODE" -m "$MODEL_PATH" -t $TARGETS --tune_params "$TUNE_HYPERPARAMETERS"
 log "✅ Finished train"
 
 log "➡️ Running get_predictions_stats_points..."

--- a/src/predictors/unified_predictor.py
+++ b/src/predictors/unified_predictor.py
@@ -216,7 +216,7 @@ class UnifiedPredictor(metaclass=SingletonMeta):
         return specific_games_df
 
     def transform_data(
-        self, data_map: dict, model: Any
+        self, data_map: dict, model: Any, encoder: Any = None
     ) -> tuple[pd.DataFrame, pd.DataFrame]:
         """
         Transform data for predictions.
@@ -224,6 +224,7 @@ class UnifiedPredictor(metaclass=SingletonMeta):
         Args:
             data_map: Dictionary containing loaded dataframes
             model: Trained model
+            encoder: Encoder used during training (for consistent encoding)
 
         Returns:
             Tuple of (predictions_df, games_played_df) where games_played_df has
@@ -282,8 +283,8 @@ class UnifiedPredictor(metaclass=SingletonMeta):
         )
 
         # Encode Categoricals
-        encoded_df, encoded_feature_names = encode_categorical_features(
-            df=df_hist, categorical_cols=self.categorical_cols
+        encoded_df, encoded_feature_names, _ = encode_categorical_features(
+            df=df_hist, categorical_cols=self.categorical_cols, encoder=encoder
         )
 
         # Get volatility
@@ -398,18 +399,21 @@ class UnifiedPredictor(metaclass=SingletonMeta):
         try:
             logger.info(f"Starting prediction pipeline for {self.target}...")
 
-            # 1. Load Model
-            logger.info(f"Loading model from: {self.model_path}...")
-            model = load_model_artifact(
+            # 1. Load Model artifact (returns full dict: model, encoder, metadata)
+            logger.info(f"Loading model artifact from: {self.model_path}...")
+            artifact = load_model_artifact(
                 model_path=self.model_path, target=self.target, mode=self.save_mode
             )
+            model   = artifact["model"]
+            encoder = artifact.get("encoder", None)
 
             # 2. Read Data
             data_map = self.read_data()
 
             # 3. Transform Data & Make Predictions
+            # encoder is passed explicitly — no hidden instance state
             predictions_df, games_played_df = self.transform_data(
-                data_map=data_map, model=model
+                data_map=data_map, model=model, encoder=encoder
             )
 
             # 4. Persist Results (includes confidence computation)

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -37,15 +37,17 @@ DEFAULT_PARAMS = {
         'colsample_bytree': 0.8
     },
     'fantasy_points': {
-        'n_estimators': 2600,
-        'learning_rate': 0.007,
-        'max_depth': 9,
-        'num_leaves': 63,
-        'subsample': 0.8,
+        'objective': 'quantile',
+        'alpha': 0.75,
+        'n_estimators': 800,        # fewer trees, quantile loss converges differently
+        'learning_rate': 0.02,      # faster than 0.007 — quantile loss is noisy
+        'max_depth': 7,             # shallower — less variance on non-smooth loss
+        'num_leaves': 50,           # down from 63
+        'subsample': 0.7,
         'colsample_bytree': 0.6,
-        'reg_alpha': 1.0,
-        'reg_lambda': 0.8,
-        'min_child_samples': 50
+        'reg_alpha': 0.5,           # reduce L1 slightly
+        'reg_lambda': 1.0,          # keep some L2
+        'min_child_samples': 40,
     }
 }
 
@@ -109,7 +111,7 @@ class UnifiedModelTrainer:
             data_map: Dictionary with raw dataframes
             
         Returns:
-            Tuple of (transformed_df, feature_cols, encoded_cols)
+            Tuple of (transformed_df, feature_cols, encoded_cols, encoder)
         """
         return transform_data(
             data_map=data_map,
@@ -120,13 +122,14 @@ class UnifiedModelTrainer:
             target_computer_fn=self.target_computer_fn
         )
 
-    def persist(self, model: Any, metrics: Dict[str, Any]) -> None:
+    def persist(self, model: Any, metrics: Dict[str, Any], encoder: Any = None) -> None:
         """
         Save trained model and metadata.
         
         Args:
             model: Trained model object
             metrics: Model performance metrics
+            encoder: Fitted encoder object (optional)
         """
         persist_model(
             model=model,
@@ -154,7 +157,7 @@ class UnifiedModelTrainer:
             data_map = self.read()
             
             # 2. Transform data
-            df, self.feature_cols, encoded_cols = self.transform(data_map)
+            df, self.feature_cols, encoded_cols, self.encoder = self.transform(data_map)
             
             # 3. Split train/test
             X_train, X_test, y_train, y_test, split_info = split_train_test(
@@ -178,7 +181,7 @@ class UnifiedModelTrainer:
             metrics.update(split_info)
             
             # 6. Persist model
-            self.persist(model=model, metrics=metrics)
+            self.persist(model=model, metrics=metrics, encoder=self.encoder)
             
             logger.info("Training pipeline completed successfully!")
             

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -93,11 +93,14 @@ class TestFeatureEngineering(unittest.TestCase):
 
     def test_encode_categorical_features(self):
         df = pd.DataFrame({"pos": ["A", "B", "A"]})
-        df, encoded_cols = encode_categorical_features(df, ["pos"])
+        # encode_categorical_features now returns (df, feature_names, encoder)
+        df, encoded_cols, encoder = encode_categorical_features(df, ["pos"])
 
         self.assertIn("pos_A", df.columns)
         self.assertIn("pos_B", df.columns)
         self.assertIn("pos_A", encoded_cols)
+        # encoder should be reusable at inference time
+        self.assertIsNotNone(encoder)
 
     def test_get_feature_cols(self):
         cols = get_feature_cols(self.key_stats, rolling_periods=[5])


### PR DESCRIPTION
## Summary

- Switch `fantasy_points` to quantile regression (`objective='quantile', alpha=0.75`) to predict the 75th percentile for TTFL upside — removes the ~48pt prediction ceiling caused by MSE regression to the mean
- Fix feature engineering normalisation bug (engineering stats were incorrectly divided by player minutes), remove `possessions_per_poss` constant feature, and serialise the `OneHotEncoder` in the model artifact to prevent column drift between training and inference
- Fix `TARGETS` env variable mismatch in `run_all.sh` — only the `points` model had been training since January due to `TARGET` vs `TARGETS` (singular/plural) naming inconsistency with Cloud Run

## Commits

- **[C024]** Add EDA notebook validating all fixes before implementation
- **[C025]** Overhaul ML pipeline: quantile objective, pinball loss evaluation, artifact dict, encoder serialisation, objective-aware hyperparameter search spaces
- **[C026]** Fix `TARGETS` env variable in `run_all.sh` + update `DEFAULT_PARAMS` for quantile priors

## Test plan

- [ ] Unit tests pass (`pytest tests/`)
- [ ] `fantasy_points` model trains successfully with `TARGETS=fantasy_points`
- [ ] `test_pinball` and `train_pinball` metrics appear in BigQuery after training run
- [ ] Predictions no longer capped at ~48 — high-upside players show values in the 55–70 range
- [ ] `points` model unaffected — verify metrics stable vs pre-PR baseline