### PR TITLE
[C032] Fix pandas 3.0 string-dtype regression in feature engineering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ project-structure.txt
 
 # Claude Code guidance — kept local only, not shared via the repo
 CLAUDE.md
+
+# macOS Finder metadata
+.DS_Store

--- a/common/feature_engineering.py
+++ b/common/feature_engineering.py
@@ -23,7 +23,7 @@ def merge_data(
     """
     # Merge boxscore df + players
     df_merged = box.merge(
-        players[["person_id", "position"]].rename(
+        players[["person_id", "position"]].rename(  # type: ignore
             columns={"position": "position_player"}
         ),
         left_on="personId",
@@ -59,7 +59,7 @@ def preprocess_data(df: pd.DataFrame) -> pd.DataFrame:
         pd.DataFrame: Preprocessed DataFrame.
     """
     # Transform minutes from string to float
-    if "minutes" in df.columns and df["minutes"].dtype == "object":
+    if "minutes" in df.columns and pd.api.types.is_string_dtype(df["minutes"]):
         df["minutes"] = df["minutes"].apply(parse_minutes)
 
     # fill NaN values in 'position' with 'BENCH'
@@ -81,11 +81,11 @@ def preprocess_data(df: pd.DataFrame) -> pd.DataFrame:
         )
 
         # Filter out players where position_group is still 'BENCH' (likely missing player info or deep bench)
-        df = df[df["position_group"] != "BENCH"]
+        df = df[df["position_group"] != "BENCH"]  # type: ignore
 
     # Remove rows with no minutes (DNP)
     if "minutes" in df.columns:
-        df = df[df["minutes"].notna()]
+        df = df[df["minutes"].notna()]  # type: ignore
 
     # Change column date type to datetime
     if "game_date" in df.columns:
@@ -149,7 +149,7 @@ def create_historical_features(
     # sort chronologically per group (oldest -> newest)
     df_avg = df_avg.sort_values(
         ["position_group", "opponent", "game_date"], ascending=[True, True, True]
-    ).reset_index(drop=True)
+    ).reset_index(drop=True)  # type: ignore
 
     # Compute rolling averages shifted by 1 to avoid data leakage
 
@@ -377,7 +377,7 @@ def get_rest_days(
     # Get unique players
     players_unique: pd.DataFrame = players_df[
         ["person_id", "team_id"]
-    ].drop_duplicates()
+    ].drop_duplicates()  # type: ignore
 
     # Get last game date for each player
     last_games: pd.DataFrame = (
@@ -396,12 +396,12 @@ def get_rest_days(
     # Calculate rest days
     rest_days_df["rest_days"] = (
         pd.to_datetime(date) - pd.to_datetime(rest_days_df["last_game_date"])
-    ).dt.days
+    ).dt.days  # type: ignore
     rest_days_df["rest_days"] = rest_days_df["rest_days"].fillna(
         7
     )  # Default to 7 days if no last game
 
-    return rest_days_df[["personId", "rest_days"]]
+    return rest_days_df[["personId", "rest_days"]]  # type: ignore
 
 
 def get_volatility(df_historical: pd.DataFrame, target_variable: str) -> pd.DataFrame:
@@ -426,7 +426,7 @@ def get_volatility(df_historical: pd.DataFrame, target_variable: str) -> pd.Data
         df_hist_sorted.sort_values("game_date")
         .groupby("personId")
         .tail(1)[["personId", "fantasy_volatility"]]
-    )
+    )  # type: ignore
 
     return volatility_df
 
@@ -492,7 +492,7 @@ def get_final_df(
         # This shouldn't happen if we merged correctly above, but as a fallback
         future_games_long["rest_days"] = 3  # default value
 
-    X_pred: pd.DataFrame = future_games_long[final_features].fillna(0)
+    X_pred: pd.DataFrame = future_games_long[final_features].fillna(0)  # type: ignore
     # DEBUG: Compare with model's expected features
     if hasattr(model, "feature_name_"):
         model_features = model.feature_name_

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas>=2.2
+pandas>=2.2,<3.0
 numpy>=2.0
 lightgbm>=4.5
 joblib>=1.5


### PR DESCRIPTION
## Summary
- pandas 3.0 (resolved from `pandas>=2.2`) changed the default dtype for
  string columns from `object` to `str`. The `minutes` dtype check in
  `common/feature_engineering.py` only matched `object`, so on pandas 3.0
  the `MM:SS` strings were never parsed and reached arithmetic ops in
  `normalize_features`, breaking 7 tests with `TypeError: operation
  'rtruediv' not supported for dtype 'str' with dtype 'int64'`.
- Fixed the check to use `pd.api.types.is_string_dtype(...)`, which covers
  both `object` and the new pandas 3.0 `str` dtype.
- Pinned `pandas>=2.2,<3.0` in `requirements.txt` to avoid silently jumping
  to an untested major version in CI/Docker.
- Added `# type: ignore` to a few lines flagged by Pylance due to known
  pandas type-stub overload limitations (`.rename`, list-column selection,
  `.dt` accessors) — no behavior change.
- Added `.DS_Store` to `.gitignore`.

## Test plan
- [x] `pytest -q` — 168 passed (previously 7 failed)