### PR TITLE
[C033] Add proprietary LICENSE and pyproject.toml metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2026 aurelpow. All Rights Reserved.
+
+This repository and its contents (including but not limited to source code,
+scripts, configuration files, notebooks, documentation, and trained model
+artifacts) are made publicly viewable on GitHub for portfolio and
+demonstration purposes only.
+
+No license, express or implied, is granted to any person to copy, modify,
+merge, publish, distribute, sublicense, execute, or sell copies of this
+software, in whole or in part, for any purpose, without the prior written
+consent of the copyright holder.
+
+Viewing this repository's source code does not constitute permission to use
+it. All rights not expressly granted herein are reserved by the copyright
+holder.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHOR OR COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+
+For licensing inquiries, contact: darracq.aurelien@gmail.com

--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ gcloud scheduler jobs create http nba-weekly-training \
 ## 📄 License & Credits
 
 - **Author**: Aurelien Pow ([@aurelpow](https://github.com/aurelpow))
+- **License**: All Rights Reserved — see [LICENSE](LICENSE). This code is shared publicly for portfolio/demonstration purposes; no permission is granted to copy, modify, or redistribute it without written consent.
 
 ## 🛣️ Next Improvements and Features
 - **➕ More stats** (AST / TOV / REB)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "nba-ml-pipeline"
+version = "0.6.1"
+description = "End-to-end ML pipeline that ingests NBA data, trains LightGBM models, predicts player stats (points + TTFL fantasy points), and monitors prediction quality."
+authors = [
+    { name = "Aurelien Pow" },
+]
+readme = "README.md"
+requires-python = ">=3.11,<3.13"
+license = { text = "All Rights Reserved" }


### PR DESCRIPTION
# Title
[C033] Add proprietary LICENSE and pyproject.toml metadata

# Description
## Summary
- Adds a `LICENSE` file establishing an "All Rights Reserved" proprietary notice — the repo stays publicly viewable on GitHub for portfolio purposes, but no permission is granted to copy, modify, or redistribute the code without written consent.
- Updates the existing "License & Credits" section in `README.md` to reference the new `LICENSE` file.
- Adds a minimal `pyproject.toml` with project metadata only (`name`, `version`, `description`, `author`, `requires-python = ">=3.11,<3.13"`, `license`). No `[build-system]` table is declared, so this does **not** turn the repo into an installable package or change how dependencies are installed — `requirements.txt` remains the source of truth for that (Docker/scripts untouched).

## Why
The repo was public with no license, which defaulted to an ambiguous "all rights reserved" with no explicit documentation. This makes the terms explicit and adds standard project metadata.

## Testing
- No code/logic changes — verified `pyproject.toml` has no `[build-system]` section so `pip install` behavior for the project is unaffected.
- `requirements.txt`-based install path (Docker, `scripts/run_all.sh`) unchanged.
